### PR TITLE
Refactor/core separation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,8 +27,14 @@ jobs:
           cache: npm
       - run: npm ci
       - run: mkdir -p dist && npm run build
+      - run: |
+          mkdir -p _site
+          cp index.html _site/
+          cp -r css fonts dist _site/
+          if [ -f CNAME ]; then cp CNAME _site/; fi
+          touch _site/.nojekyll
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: .
+          path: _site
       - id: deployment
         uses: actions/deploy-pages@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,9 @@ Use **2-space indentation** and **semicolon-free** syntax. Use **single quotes**
 - Install: `npm install`
 - Tests: `npm test` (runs unit tests + Playwright E2E)
 - Lint/format: Not configured; use `npm run build-dev` as a fast sanity build
-- CLI: `node src/cli/index.js data.csv` (outputs JSON profiling result)
+- CLI:
+  - `node src/cli/index.js data.csv` (auto: summary on TTY, JSON when piped)
+  - `node src/cli/index.js data.csv --format json|summary|serve`
 
 ## Repo map
 - `src/core/`: pure-JS profiling engine (no DOM deps)
@@ -26,9 +28,12 @@ Use **2-space indentation** and **semicolon-free** syntax. Use **single quotes**
   - `columns.js`: `initColumns()`, `updateColumns()` — online-stats wrappers
   - `result.js`: `finalizeResult()` — builds versioned ProfileResult (v1)
 - `src/render/index.js`: DOM/chart rendering (tui-chart), consumes ProfileResult
-- `src/worker/profile-worker.js`: Web Worker — runs core in background thread
-- `src/main.js`: browser entry — DnD/input handlers, Worker dispatch, render
-- `src/cli/index.js`: CLI entry — `fs.createReadStream` → core → JSON output
+- `src/worker/profile-worker.js`: Web Worker — runs core in background thread (file + URL jobs)
+- `src/main.js`: browser entry — DnD/file/url handlers, Worker dispatch, render
+- `src/cli/index.js`: CLI entry — `fs.createReadStream`/stdin → core → formatter (`json|summary|serve`)
+- `src/cli/progress.js`: CLI progress renderer (spinner/progress bar)
+- `src/cli/format-summary.js`: ANSI terminal summary formatter
+- `src/cli/serve.js`: local report server for `--format serve` (`/api/result` + browser open)
 - `index.html`: UI shell and app entrypoint
 - `css/`: app styles and vendor chart CSS
 - `dist/bundle.js`: built browser bundle (generated)
@@ -41,7 +46,7 @@ Use **2-space indentation** and **semicolon-free** syntax. Use **single quotes**
 ## Definition of done
 - Run: `npm run build` (or `npm run build-dev` during iteration)
 - Add/adjust unit tests for core logic (classify, columns, result) in `tests/unit/`
-- Add/adjust E2E tests for browser upload flow in `tests/e2e/`
+- Add/adjust E2E tests for browser upload flow + URL flow in `tests/e2e/`
 - If you can't run tests: explain + add a minimal verification note
 
 ## Constraints

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,27 +14,41 @@ Use **2-space indentation** and **semicolon-free** syntax. Use **single quotes**
 
 ## Quick start
 - Install: `npm install`
-- Tests: `npm test` (runs Playwright E2E against a local static server)
+- Tests: `npm test` (runs unit tests + Playwright E2E)
 - Lint/format: Not configured; use `npm run build-dev` as a fast sanity build
+- CLI: `node src/cli/index.js data.csv` (outputs JSON profiling result)
 
 ## Repo map
-- `src/main.js`: core browser app (streaming CSV parse, stats aggregation, output rendering)
+- `src/core/`: pure-JS profiling engine (no DOM deps)
+  - `index.js`: `profileStream(readable, opts)` — main API
+  - `constants.js`: shared constants (missing markers, thresholds, stats conventions)
+  - `classify.js`: `classifyValue()`, `getVariableType()` — pure functions
+  - `columns.js`: `initColumns()`, `updateColumns()` — online-stats wrappers
+  - `result.js`: `finalizeResult()` — builds versioned ProfileResult (v1)
+- `src/render/index.js`: DOM/chart rendering (tui-chart), consumes ProfileResult
+- `src/worker/profile-worker.js`: Web Worker — runs core in background thread
+- `src/main.js`: browser entry — DnD/input handlers, Worker dispatch, render
+- `src/cli/index.js`: CLI entry — `fs.createReadStream` → core → JSON output
 - `index.html`: UI shell and app entrypoint
 - `css/`: app styles and vendor chart CSS
 - `dist/bundle.js`: built browser bundle (generated)
+- `dist/worker-bundle.js`: built worker bundle (generated)
 - `fonts/`: local Roboto font assets
+- `tests/unit/`: tape unit tests for core modules
 - `tests/e2e/`: Playwright browser-level regression tests
 - `tests/support/`: local static server used by E2E tests
-- `docs/architecture.md`: not present in this repo
 
 ## Definition of done
 - Run: `npm run build` (or `npm run build-dev` during iteration)
-- Add/adjust tests for: browser upload flow, streaming parse behavior, missing-value classification, numeric stats gating, and top-value counting in `src/main.js`
-- If you can’t run tests: explain + add a minimal verification note
+- Add/adjust unit tests for core logic (classify, columns, result) in `tests/unit/`
+- Add/adjust E2E tests for browser upload flow in `tests/e2e/`
+- If you can't run tests: explain + add a minimal verification note
 
 ## Constraints
 - Don’t add new production dependencies without asking.
 - No DB migrations exist in this repo; ask before introducing any persistence layer or migration tooling.
+- Update the `README.md`, `CHANGELOG.md` and `index.html` with any user-facing changes or new features.
+- Commit messages should be clear and descriptive, following the format: `feature|fix|test|docs: short description` (e.g., `feature: add new column type classification`).
 
 ## Conventions
 - Formatting: no formatter is configured; preserve existing style (2-space indentation, semicolon-free, single quotes)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Anton Zemlyansky
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,32 @@
-## Profile
+## StatSim Profile
 
-Generate data profiles in the browser. Data is processed locally as a stream. In theory you can process really big files because online algorithms are awesome!
+Generate data profiles in the browser or from the command line. Data is processed locally as a stream using online algorithms, so you can handle very large files without loading them into memory.
 
-* CSV
-* Count missing values
-* Statistics (min, max, mean, std)
-* Top N
+### Features
+
+* CSV and TSV support
+* Streaming processing via Web Workers (UI stays responsive)
+* Missing value detection (empty, NA, NULL, NaN, etc.)
+* Descriptive statistics (min, max, mean, variance, std)
+* Histograms and top-N value counts
+* Variable type classification (Number, String, Boolean, Categorical, Mixed)
+* Load files from URL via query param: `?file=https://example.com/data.csv`
+* CLI tool for scripting: `npx statsim-profile data.csv`
+
+### Usage
+
+**Browser:** Open [statsim.com/profile](https://statsim.com/profile/), drag a CSV file or paste a URL.
+
+**CLI:**
+```
+npx statsim-profile data.csv          # profile a file, output JSON
+cat data.csv | npx statsim-profile --stdin  # read from stdin
+```
+
+### Development
+
+```
+npm install
+npm run build-dev   # build browser bundles
+npm test            # run unit + E2E tests
+```

--- a/README.md
+++ b/README.md
@@ -11,16 +11,20 @@ Generate data profiles in the browser or from the command line. Data is processe
 * Histograms and top-N value counts
 * Variable type classification (Number, String, Boolean, Categorical, Mixed)
 * Load files from URL via query param: `?file=https://example.com/data.csv`
-* CLI tool for scripting: `npx statsim-profile data.csv`
+* CLI output modes: `summary`, `json`, and `serve`
+* npm package: `@statsim/profile`
 
 ### Usage
 
-**Browser:** Open [statsim.com/profile](https://statsim.com/profile/), drag a CSV file or paste a URL.
+**Browser:** Open [statsim.com/profile](https://statsim.com/profile/), drag a CSV file, paste a URL, or open a prefilled link such as `?file=https://example.com/data.csv`.
 
 **CLI:**
 ```
-npx statsim-profile data.csv          # profile a file, output JSON
-cat data.csv | npx statsim-profile --stdin  # read from stdin
+npx @statsim/profile data.csv
+sprofile data.csv                       # summary (TTY)
+sprofile data.csv --format json         # raw JSON
+sprofile data.csv --format serve        # open local browser report
+cat data.csv | sprofile --stdin         # stdin mode
 ```
 
 ### Development

--- a/css/main.css
+++ b/css/main.css
@@ -62,6 +62,17 @@ dd {
   height: 3px;
 }
 
+#progress.indeterminate {
+  width: 100% !important;
+  animation: indeterminate 1.5s infinite ease-in-out;
+}
+
+@keyframes indeterminate {
+  0% { opacity: 0.3; }
+  50% { opacity: 1; }
+  100% { opacity: 0.3; }
+}
+
 #output h2 {
   font-size: 42px;
   font-weight: 700;

--- a/index.html
+++ b/index.html
@@ -48,6 +48,11 @@
           <div class="drag-text">
             <h4>Drag & drop a CSV file</h4>
             <p>Or <label for="input" style="color:#039be5; cursor: pointer; font-size: 14px;">choose a file</label></p>
+            <div class="url-input" style="margin-top: 16px;">
+              <input id="url-input" type="text" placeholder="Or paste a CSV URL (https://...)" style="width: 400px; max-width: 80%; padding: 4px 8px; font-size: 14px; border: 1px solid #ccc; border-radius: 3px;">
+              <button id="url-load" style="padding: 4px 12px; font-size: 14px; cursor: pointer; margin-left: 4px;">Load</button>
+            </div>
+            <p id="url-error" style="color: #e53935; font-size: 13px; display: none;"></p>
           </div>
         </div>
       </div>
@@ -60,7 +65,7 @@
             <h1>Data profiling online</h1>
             <h2>Use this free and open-source web app to profile data and generate visual summaries of your CSV datasets</h2>
             <p>
-              In many industries, understanding data is a vital skill. However, most people struggle to recognize patterns and extract insights from raw tabular datasets because we are not computers. That's why data visualization and profiling are invaluable tools, frequently utilized to transform raw numbers into comprehensible elements like charts, trends, and statistics. Data profiling enables the creation of overviews of tabular files, offering detailed information and descriptive statistics for each variable contained in a dataset. <b>StatSim Profile</b> is a browser-based data profiling tool that is free and open-source. It processes files locally without uploading them to a web server and can handle large datasets, even those in gigabytes.
+              In many industries, understanding data is a vital skill. However, most people struggle to recognize patterns and extract insights from raw tabular datasets because we are not computers. That's why data visualization and profiling are invaluable tools, frequently utilized to transform raw numbers into comprehensible elements like charts, trends, and statistics. Data profiling enables the creation of overviews of tabular files, offering detailed information and descriptive statistics for each variable contained in a dataset. <b>StatSim Profile</b> is a browser-based data profiling tool that is free and open-source. It processes files locally without uploading them to a web server and can handle large datasets, even those in gigabytes. You can also load CSV files directly from a URL or use the <a href="https://github.com/statsim/profile">command-line tool</a> for scripting.
             </p>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -52,6 +52,7 @@
               <input id="url-input" type="text" placeholder="Or paste a CSV URL (https://...)" style="width: 400px; max-width: 80%; padding: 4px 8px; font-size: 14px; border: 1px solid #ccc; border-radius: 3px;">
               <button id="url-load" style="padding: 4px 12px; font-size: 14px; cursor: pointer; margin-left: 4px;">Load</button>
             </div>
+            <p style="font-size: 13px; color: #666; margin-top: 8px;">Tip: you can also open <code>?file=https://example.com/data.csv</code></p>
             <p id="url-error" style="color: #e53935; font-size: 13px; display: none;"></p>
           </div>
         </div>
@@ -65,7 +66,7 @@
             <h1>Data profiling online</h1>
             <h2>Use this free and open-source web app to profile data and generate visual summaries of your CSV datasets</h2>
             <p>
-              In many industries, understanding data is a vital skill. However, most people struggle to recognize patterns and extract insights from raw tabular datasets because we are not computers. That's why data visualization and profiling are invaluable tools, frequently utilized to transform raw numbers into comprehensible elements like charts, trends, and statistics. Data profiling enables the creation of overviews of tabular files, offering detailed information and descriptive statistics for each variable contained in a dataset. <b>StatSim Profile</b> is a browser-based data profiling tool that is free and open-source. It processes files locally without uploading them to a web server and can handle large datasets, even those in gigabytes. You can also load CSV files directly from a URL or use the <a href="https://github.com/statsim/profile">command-line tool</a> for scripting.
+              In many industries, understanding data is a vital skill. However, most people struggle to recognize patterns and extract insights from raw tabular datasets because we are not computers. That's why data visualization and profiling are invaluable tools, frequently utilized to transform raw numbers into comprehensible elements like charts, trends, and statistics. Data profiling enables the creation of overviews of tabular files, offering detailed information and descriptive statistics for each variable contained in a dataset. <b>StatSim Profile</b> is a browser-based data profiling tool that is free and open-source. It processes files locally without uploading them to a web server and can handle large datasets, even those in gigabytes. Processing runs in a Web Worker to keep the UI responsive. You can also load CSV files directly from a URL or use the <a href="https://github.com/statsim/profile">command-line tool</a> with <code>summary</code>, <code>json</code>, and <code>serve</code> output modes.
             </p>
           </div>
         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
       "devDependencies": {
         "@playwright/test": "^1.49.1",
         "browserify": "^16.5.0",
-        "nodemon": "^1.19.4",
+        "nodemon": "^3.1.11",
         "tape": "^4.11.0",
         "uglify-es": "^3.3.9"
       }
@@ -77,92 +77,17 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/ansi-align": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
-      "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^2.0.0"
-      }
-    },
-    "node_modules/ansi-regex": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
-      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/anymatch": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-      "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "dev": true,
       "dependencies": {
-        "micromatch": "^3.1.4",
-        "normalize-path": "^2.1.1"
-      }
-    },
-    "node_modules/anymatch/node_modules/normalize-path": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "dev": true,
-      "dependencies": {
-        "remove-trailing-separator": "^1.0.1"
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
       },
       "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/arr-diff": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/arr-flatten": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/arr-union": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/array-unique": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
+        "node": ">= 8"
       }
     },
     "node_modules/asn1.js": {
@@ -199,33 +124,6 @@
       "dev": true,
       "dependencies": {
         "inherits": "2.0.1"
-      }
-    },
-    "node_modules/assign-symbols": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/async-each": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
-      "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
-      "dev": true
-    },
-    "node_modules/atob": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-      "dev": true,
-      "bin": {
-        "atob": "bin/atob.js"
-      },
-      "engines": {
-        "node": ">= 4.5.0"
       }
     },
     "node_modules/available-typed-arrays": {
@@ -273,76 +171,6 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
-    "node_modules/base": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
-      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
-      "dev": true,
-      "dependencies": {
-        "cache-base": "^1.0.1",
-        "class-utils": "^0.3.5",
-        "component-emitter": "^1.2.1",
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.1",
-        "mixin-deep": "^1.2.0",
-        "pascalcase": "^0.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/base/node_modules/define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-      "dev": true,
-      "dependencies": {
-        "is-descriptor": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/base/node_modules/is-accessor-descriptor": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-      "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-      "deprecated": "Please upgrade to v1.0.1",
-      "dev": true,
-      "dependencies": {
-        "kind-of": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/base/node_modules/is-data-descriptor": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-      "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-      "deprecated": "Please upgrade to v1.0.1",
-      "dev": true,
-      "dependencies": {
-        "kind-of": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/base/node_modules/is-descriptor": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-      "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-      "dev": true,
-      "dependencies": {
-        "is-accessor-descriptor": "^1.0.0",
-        "is-data-descriptor": "^1.0.0",
-        "kind-of": "^6.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/base64-js": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
@@ -350,22 +178,15 @@
       "dev": true
     },
     "node_modules/binary-extensions": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
-      "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
       "dev": true,
       "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/bn.js": {
@@ -373,24 +194,6 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
       "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
       "dev": true
-    },
-    "node_modules/boxen": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
-      "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
-      "dev": true,
-      "dependencies": {
-        "ansi-align": "^2.0.0",
-        "camelcase": "^4.0.0",
-        "chalk": "^2.0.1",
-        "cli-boxes": "^1.0.0",
-        "string-width": "^2.0.0",
-        "term-size": "^1.2.0",
-        "widest-line": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -403,36 +206,15 @@
       }
     },
     "node_modules/braces": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "arr-flatten": "^1.1.0",
-        "array-unique": "^0.3.2",
-        "extend-shallow": "^2.0.1",
-        "fill-range": "^4.0.0",
-        "isobject": "^3.0.1",
-        "repeat-element": "^1.1.2",
-        "snapdragon": "^0.8.1",
-        "snapdragon-node": "^2.0.1",
-        "split-string": "^3.0.2",
-        "to-regex": "^3.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/braces/node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-      "dev": true,
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8"
       }
     },
     "node_modules/brorand": {
@@ -675,26 +457,6 @@
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
     },
-    "node_modules/cache-base": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
-      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
-      "dev": true,
-      "dependencies": {
-        "collection-visit": "^1.0.0",
-        "component-emitter": "^1.2.1",
-        "get-value": "^2.0.6",
-        "has-value": "^1.0.0",
-        "isobject": "^3.0.1",
-        "set-value": "^2.0.0",
-        "to-object-path": "^0.3.0",
-        "union-value": "^1.0.0",
-        "unset-value": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/cached-path-relative": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.1.0.tgz",
@@ -748,65 +510,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/camelcase": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/capture-stack-trace": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
-      "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "dev": true,
       "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
       },
       "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/chokidar": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
-      "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
-      "dev": true,
-      "dependencies": {
-        "anymatch": "^2.0.0",
-        "async-each": "^1.0.1",
-        "braces": "^2.3.2",
-        "glob-parent": "^3.1.0",
-        "inherits": "^2.0.3",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^4.0.0",
-        "normalize-path": "^3.0.0",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.2.1",
-        "upath": "^1.1.1"
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       },
       "optionalDependencies": {
-        "fsevents": "^1.2.7"
+        "fsevents": "~2.3.2"
       }
-    },
-    "node_modules/ci-info": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-      "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
-      "dev": true
     },
     "node_modules/cipher-base": {
       "version": "1.0.7",
@@ -822,42 +548,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/class-utils": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
-      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
-      "dev": true,
-      "dependencies": {
-        "arr-union": "^3.1.0",
-        "define-property": "^0.2.5",
-        "isobject": "^3.0.0",
-        "static-extend": "^0.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/class-utils/node_modules/define-property": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-      "dev": true,
-      "dependencies": {
-        "is-descriptor": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/cli-boxes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/clone": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
@@ -865,34 +555,6 @@
       "engines": {
         "node": ">=0.8"
       }
-    },
-    "node_modules/collection-visit": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
-      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
-      "dev": true,
-      "dependencies": {
-        "map-visit": "^1.0.0",
-        "object-visit": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
     },
     "node_modules/combine-source-map": {
       "version": "0.8.0",
@@ -910,12 +572,6 @@
       "version": "2.13.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
       "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
-      "dev": true
-    },
-    "node_modules/component-emitter": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
     },
     "node_modules/concat-map": {
@@ -939,23 +595,6 @@
         "typedarray": "^0.0.6"
       }
     },
-    "node_modules/configstore": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
-      "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
-      "dev": true,
-      "dependencies": {
-        "dot-prop": "^4.1.0",
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^1.0.0",
-        "unique-string": "^1.0.0",
-        "write-file-atomic": "^2.0.0",
-        "xdg-basedir": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/console-browserify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
@@ -977,15 +616,6 @@
       "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
       "dev": true
     },
-    "node_modules/copy-descriptor": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/core-js": {
       "version": "2.6.10",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
@@ -999,25 +629,13 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "node_modules/create-ecdh": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
-      "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+      "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
       "dev": true,
       "dependencies": {
         "bn.js": "^4.1.0",
-        "elliptic": "^6.0.0"
-      }
-    },
-    "node_modules/create-error-class": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
-      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-      "dev": true,
-      "dependencies": {
-        "capture-stack-trace": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
+        "elliptic": "^6.5.3"
       }
     },
     "node_modules/create-hash": {
@@ -1047,17 +665,6 @@
         "sha.js": "^2.4.8"
       }
     },
-    "node_modules/cross-spawn": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
-      }
-    },
     "node_modules/crypto-browserify": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
@@ -1078,15 +685,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/crypto-random-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/csv-parse": {
@@ -1110,27 +708,20 @@
       "dev": true
     },
     "node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/debug/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
-    "node_modules/decode-uri-component": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
-      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
-      "dev": true,
+        "ms": "^2.1.3"
+      },
       "engines": {
-        "node": ">=0.10"
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/deep-equal": {
@@ -1138,15 +729,6 @@
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
       "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
       "dev": true
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0.0"
-      }
     },
     "node_modules/defaults": {
       "version": "1.0.3",
@@ -1183,59 +765,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/define-property": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
-      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
-      "dev": true,
-      "dependencies": {
-        "is-descriptor": "^1.0.2",
-        "isobject": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/define-property/node_modules/is-accessor-descriptor": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-      "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-      "deprecated": "Please upgrade to v1.0.1",
-      "dev": true,
-      "dependencies": {
-        "kind-of": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/define-property/node_modules/is-data-descriptor": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-      "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-      "deprecated": "Please upgrade to v1.0.1",
-      "dev": true,
-      "dependencies": {
-        "kind-of": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/define-property/node_modules/is-descriptor": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-      "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-      "dev": true,
-      "dependencies": {
-        "is-accessor-descriptor": "^1.0.0",
-        "is-data-descriptor": "^1.0.0",
-        "kind-of": "^6.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/defined": {
@@ -1317,18 +846,6 @@
         "npm": ">=1.2"
       }
     },
-    "node_modules/dot-prop": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
-      "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
-      "dev": true,
-      "dependencies": {
-        "is-obj": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/drag-and-drop-files": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/drag-and-drop-files/-/drag-and-drop-files-0.0.1.tgz",
@@ -1356,12 +873,6 @@
       "dependencies": {
         "readable-stream": "^2.0.2"
       }
-    },
-    "node_modules/duplexer3": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-      "dev": true
     },
     "node_modules/elliptic": {
       "version": "6.6.1",
@@ -1443,15 +954,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/eve": {
       "version": "0.4.1",
       "resolved": "git+ssh://git@github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1",
@@ -1476,190 +978,6 @@
         "safe-buffer": "^5.1.1"
       }
     },
-    "node_modules/execa": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-      "integrity": "sha512-RztN09XglpYI7aBBrJCPW95jEH7YF1UEPOoX9yDhUTPdp7mK+CQvnLTuD10BNXZ3byLTu2uehZ8EcKT/4CGiFw==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/expand-brackets": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-      "dev": true,
-      "dependencies": {
-        "debug": "^2.3.3",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "posix-character-classes": "^0.1.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/expand-brackets/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/expand-brackets/node_modules/define-property": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-      "dev": true,
-      "dependencies": {
-        "is-descriptor": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/expand-brackets/node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-      "dev": true,
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/extend-shallow": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-      "dev": true,
-      "dependencies": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/extend-shallow/node_modules/is-extendable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-      "dev": true,
-      "dependencies": {
-        "is-plain-object": "^2.0.4"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/extglob": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-      "dev": true,
-      "dependencies": {
-        "array-unique": "^0.3.2",
-        "define-property": "^1.0.0",
-        "expand-brackets": "^2.1.4",
-        "extend-shallow": "^2.0.1",
-        "fragment-cache": "^0.2.1",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/extglob/node_modules/define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-      "dev": true,
-      "dependencies": {
-        "is-descriptor": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/extglob/node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-      "dev": true,
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/extglob/node_modules/is-accessor-descriptor": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-      "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-      "deprecated": "Please upgrade to v1.0.1",
-      "dev": true,
-      "dependencies": {
-        "kind-of": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/extglob/node_modules/is-data-descriptor": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-      "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-      "deprecated": "Please upgrade to v1.0.1",
-      "dev": true,
-      "dependencies": {
-        "kind-of": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/extglob/node_modules/is-descriptor": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-      "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-      "dev": true,
-      "dependencies": {
-        "is-accessor-descriptor": "^1.0.0",
-        "is-data-descriptor": "^1.0.0",
-        "kind-of": "^6.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true,
-      "optional": true
-    },
     "node_modules/filestream": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/filestream/-/filestream-5.0.0.tgz",
@@ -1683,30 +1001,15 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
-        "extend-shallow": "^2.0.1",
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1",
-        "to-regex-range": "^2.1.0"
+        "to-regex-range": "^5.0.1"
       },
       "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/fill-range/node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-      "dev": true,
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8"
       }
     },
     "node_modules/for-each": {
@@ -1724,27 +1027,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/for-in": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/fragment-cache": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
-      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
-      "dev": true,
-      "dependencies": {
-        "map-cache": "^0.2.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1752,22 +1034,17 @@
       "dev": true
     },
     "node_modules/fsevents": {
-      "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-      "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-      "deprecated": "Upgrade to fsevents v2 to mitigate potential security issues",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
       ],
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "nan": "^2.12.1"
-      },
       "engines": {
-        "node": ">= 4.0"
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -1822,24 +1099,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/get-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/get-value": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/glob": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
@@ -1859,37 +1118,15 @@
       }
     },
     "node_modules/glob-parent": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "dependencies": {
-        "is-glob": "^3.1.0",
-        "path-dirname": "^1.0.0"
-      }
-    },
-    "node_modules/glob-parent/node_modules/is-glob": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-      "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-      "dev": true,
-      "dependencies": {
-        "is-extglob": "^2.1.0"
+        "is-glob": "^4.0.1"
       },
       "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/global-dirs": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
-      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
-      "dev": true,
-      "dependencies": {
-        "ini": "^1.3.4"
-      },
-      "engines": {
-        "node": ">=4"
+        "node": ">= 6"
       }
     },
     "node_modules/gopd": {
@@ -1903,34 +1140,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/got": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
-      "integrity": "sha512-Y/K3EDuiQN9rTZhBvPRWMLXIKdeD1Rj0nzunfoi0Yyn5WBEbzxXKU9Ub2X41oZBagVWOBU3MuDonFMgPWQFnwg==",
-      "dev": true,
-      "dependencies": {
-        "create-error-class": "^3.0.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^3.0.0",
-        "is-redirect": "^1.0.0",
-        "is-retry-allowed": "^1.0.0",
-        "is-stream": "^1.0.0",
-        "lowercase-keys": "^1.0.0",
-        "safe-buffer": "^5.0.1",
-        "timed-out": "^4.0.0",
-        "unzip-response": "^2.0.1",
-        "url-parse-lax": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/graceful-fs": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
-      "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
-      "dev": true
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -1947,7 +1156,7 @@
     "node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -1990,45 +1199,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
-      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
-      "dev": true,
-      "dependencies": {
-        "get-value": "^2.0.6",
-        "has-values": "^1.0.0",
-        "isobject": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/has-values": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
-      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
-      "dev": true,
-      "dependencies": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/has-values/node_modules/kind-of": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-      "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-      "dev": true,
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/hash-base": {
@@ -2111,24 +1281,6 @@
       "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
       "dev": true
     },
-    "node_modules/import-lazy": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/imurmurhash": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.19"
-      }
-    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -2144,12 +1296,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true
     },
     "node_modules/inline-source-map": {
       "version": "0.6.2",
@@ -2191,41 +1337,16 @@
         "xtend": "~4.0.1"
       }
     },
-    "node_modules/is-accessor-descriptor": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-      "deprecated": "Please upgrade to v0.1.7",
-      "dev": true,
-      "dependencies": {
-        "kind-of": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-accessor-descriptor/node_modules/kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-binary-path": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "dev": true,
       "dependencies": {
-        "binary-extensions": "^1.0.0"
+        "binary-extensions": "^2.0.0"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8"
       }
     },
     "node_modules/is-buffer": {
@@ -2246,43 +1367,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-ci": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
-      "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
-      "dev": true,
-      "dependencies": {
-        "ci-info": "^1.5.0"
-      },
-      "bin": {
-        "is-ci": "bin.js"
-      }
-    },
-    "node_modules/is-data-descriptor": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-      "deprecated": "Please upgrade to v0.1.5",
-      "dev": true,
-      "dependencies": {
-        "kind-of": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-data-descriptor/node_modules/kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
@@ -2292,60 +1376,19 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/is-descriptor": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-      "dev": true,
-      "dependencies": {
-        "is-accessor-descriptor": "^0.1.6",
-        "is-data-descriptor": "^0.1.4",
-        "kind-of": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-descriptor/node_modules/kind-of": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-      "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-extendable": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/is-glob": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -2354,92 +1397,13 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-installed-globally": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
-      "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
-      "dev": true,
-      "dependencies": {
-        "global-dirs": "^0.1.0",
-        "is-path-inside": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/is-npm": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-number": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-      "dev": true,
-      "dependencies": {
-        "kind-of": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-number/node_modules/kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
       "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-path-inside": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-      "dev": true,
-      "dependencies": {
-        "path-is-inside": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-plain-object": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "dev": true,
-      "dependencies": {
-        "isobject": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-redirect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
+        "node": ">=0.12.0"
       }
     },
     "node_modules/is-regex": {
@@ -2452,24 +1416,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/is-retry-allowed": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-symbol": {
@@ -2504,34 +1450,10 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
-    "node_modules/is-windows": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-    },
-    "node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
-    },
-    "node_modules/isobject": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/json-stable-stringify": {
       "version": "0.0.1",
@@ -2576,15 +1498,6 @@
         "node": "*"
       }
     },
-    "node_modules/kind-of": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/labeled-stream-splicer": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.2.tgz",
@@ -2593,18 +1506,6 @@
       "dependencies": {
         "inherits": "^2.0.1",
         "stream-splicer": "^2.0.0"
-      }
-    },
-    "node_modules/latest-version": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
-      "integrity": "sha512-Be1YRHWWlZaSsrz2U+VInk+tO0EwLIyV+23RhWLINJYwg/UIikxjlj3MhH37/6/EDCAusjajvMkMMUXRaMWl/w==",
-      "dev": true,
-      "dependencies": {
-        "package-json": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/linear-algebra": {
@@ -2617,58 +1518,6 @@
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
       "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
       "dev": true
-    },
-    "node_modules/lowercase-keys": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-      "dev": true,
-      "dependencies": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
-      }
-    },
-    "node_modules/make-dir": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
-      "dev": true,
-      "dependencies": {
-        "pify": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/map-cache": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/map-visit": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
-      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
-      "dev": true,
-      "dependencies": {
-        "object-visit": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -2688,30 +1537,6 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
-      }
-    },
-    "node_modules/micromatch": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-      "dev": true,
-      "dependencies": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "braces": "^2.3.1",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "extglob": "^2.0.4",
-        "fragment-cache": "^0.2.1",
-        "kind-of": "^6.0.2",
-        "nanomatch": "^1.2.9",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/miller-rabin": {
@@ -2758,31 +1583,6 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/mixin-deep": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
-      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
-      "dev": true,
-      "dependencies": {
-        "for-in": "^1.0.2",
-        "is-extendable": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/mixin-deep/node_modules/is-extendable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-      "dev": true,
-      "dependencies": {
-        "is-plain-object": "^2.0.4"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/mkdirp": {
@@ -2837,63 +1637,37 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
-    "node_modules/nan": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/nanomatch": {
-      "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
-      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
-      "dev": true,
-      "dependencies": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "fragment-cache": "^0.2.1",
-        "is-windows": "^1.0.2",
-        "kind-of": "^6.0.2",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/nodemon": {
-      "version": "1.19.4",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.19.4.tgz",
-      "integrity": "sha512-VGPaqQBNk193lrJFotBU8nvWZPqEZY2eIzymy2jjY0fJ9qIsxA0sxQ8ATPl0gZC645gijYEc1jtZvpS8QWzJGQ==",
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.11.tgz",
+      "integrity": "sha512-is96t8F/1//UHAjNPHpbsNY46ELPpftGUoSVNXwUfMk/qdjSylYrWSu1XavVTBOn526kFiOR733ATgNBCQyH0g==",
       "dev": true,
-      "hasInstallScript": true,
       "dependencies": {
-        "chokidar": "^2.1.8",
-        "debug": "^3.2.6",
+        "chokidar": "^3.5.2",
+        "debug": "^4",
         "ignore-by-default": "^1.0.1",
-        "minimatch": "^3.0.4",
-        "pstree.remy": "^1.1.7",
-        "semver": "^5.7.1",
+        "minimatch": "^3.1.2",
+        "pstree.remy": "^1.1.8",
+        "semver": "^7.5.3",
+        "simple-update-notifier": "^2.0.0",
         "supports-color": "^5.5.0",
         "touch": "^3.1.0",
-        "undefsafe": "^2.0.2",
-        "update-notifier": "^2.5.0"
+        "undefsafe": "^2.0.5"
       },
       "bin": {
         "nodemon": "bin/nodemon.js"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nodemon"
       }
     },
     "node_modules/nopt": {
@@ -2920,61 +1694,11 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/npm-run-path": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-      "dev": true,
-      "dependencies": {
-        "path-key": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-copy": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
-      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
-      "dev": true,
-      "dependencies": {
-        "copy-descriptor": "^0.1.0",
-        "define-property": "^0.2.5",
-        "kind-of": "^3.0.3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-copy/node_modules/define-property": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-      "dev": true,
-      "dependencies": {
-        "is-descriptor": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-copy/node_modules/kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2992,30 +1716,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/object-visit": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
-      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
-      "dev": true,
-      "dependencies": {
-        "isobject": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object.pick": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
-      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
-      "dev": true,
-      "dependencies": {
-        "isobject": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/once": {
@@ -3137,30 +1837,6 @@
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
       "dev": true
     },
-    "node_modules/p-finally": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/package-json": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
-      "integrity": "sha512-q/R5GrMek0vzgoomq6rm9OX+3PQve8sLwTirmK30YB3Cu0Bbt9OX9M/SIUnroN5BGJkzwGsFwDaRGD9EwBOlCA==",
-      "dev": true,
-      "dependencies": {
-        "got": "^6.7.1",
-        "registry-auth-token": "^3.0.1",
-        "registry-url": "^3.0.3",
-        "semver": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/pad": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/pad/-/pad-3.2.0.tgz",
@@ -3203,25 +1879,10 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/pascalcase": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/path-browserify": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
       "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
-      "dev": true
-    },
-    "node_modules/path-dirname": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
       "dev": true
     },
     "node_modules/path-is-absolute": {
@@ -3231,21 +1892,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/path-is-inside": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-      "dev": true
-    },
-    "node_modules/path-key": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/path-parse": {
@@ -3280,13 +1926,16 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/pify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
       "engines": {
-        "node": ">=4"
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/playwright": {
@@ -3333,15 +1982,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/posix-character-classes": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -3349,15 +1989,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/prepend-http": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/process": {
@@ -3374,16 +2005,10 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
-    "node_modules/pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "dev": true
-    },
     "node_modules/pstree.remy": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.7.tgz",
-      "integrity": "sha512-xsMgrUwRpuGskEzBFkH8NmTimbZ5PcPup0LA8JJkHIm2IMUbQcpo3yeLNWVrufEYjh8YwtSVh0xz6UeWc5Oh5A==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
+      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
       "dev": true
     },
     "node_modules/public-encrypt": {
@@ -3453,21 +2078,6 @@
         "eve": "git://github.com/adobe-webplatform/eve.git#eef80ed"
       }
     },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "dev": true,
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
     "node_modules/read-only-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
@@ -3505,82 +2115,21 @@
       }
     },
     "node_modules/readdirp": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-      "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dev": true,
       "dependencies": {
-        "graceful-fs": "^4.1.11",
-        "micromatch": "^3.1.10",
-        "readable-stream": "^2.0.2"
+        "picomatch": "^2.2.1"
       },
       "engines": {
-        "node": ">=0.10"
+        "node": ">=8.10.0"
       }
     },
     "node_modules/regenerator-runtime": {
       "version": "0.10.5",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
       "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
-    },
-    "node_modules/regex-not": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
-      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
-      "dev": true,
-      "dependencies": {
-        "extend-shallow": "^3.0.2",
-        "safe-regex": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/registry-auth-token": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
-      "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
-      "dev": true,
-      "dependencies": {
-        "rc": "^1.1.6",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/registry-url": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
-      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-      "dev": true,
-      "dependencies": {
-        "rc": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/remove-trailing-separator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-      "dev": true
-    },
-    "node_modules/repeat-element": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
-      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10"
-      }
     },
     "node_modules/resolve": {
       "version": "1.12.0",
@@ -3591,13 +2140,6 @@
         "path-parse": "^1.0.6"
       }
     },
-    "node_modules/resolve-url": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-      "deprecated": "https://github.com/lydell/resolve-url#deprecated",
-      "dev": true
-    },
     "node_modules/resumer": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
@@ -3605,15 +2147,6 @@
       "dev": true,
       "dependencies": {
         "through": "~2.3.4"
-      }
-    },
-    "node_modules/ret": {
-      "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.12"
       }
     },
     "node_modules/ripemd160": {
@@ -3648,34 +2181,16 @@
         }
       ]
     },
-    "node_modules/safe-regex": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
-      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
-      "dev": true,
-      "dependencies": {
-        "ret": "~0.1.10"
-      }
-    },
     "node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/semver-diff": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
-      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
-      "dev": true,
-      "dependencies": {
-        "semver": "^5.0.3"
+        "semver": "bin/semver.js"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=10"
       }
     },
     "node_modules/set-function-length": {
@@ -3693,33 +2208,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/set-value": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
-      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
-      "dev": true,
-      "dependencies": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/set-value/node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-      "dev": true,
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/sha.js": {
@@ -3752,27 +2240,6 @@
         "sha.js": "~2.4.4"
       }
     },
-    "node_modules/shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true,
-      "dependencies": {
-        "shebang-regex": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/shell-quote": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
@@ -3785,158 +2252,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/signal-exit": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
-    },
     "node_modules/simple-concat": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
       "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
       "dev": true
     },
-    "node_modules/snapdragon": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
-      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+    "node_modules/simple-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
       "dev": true,
       "dependencies": {
-        "base": "^0.11.1",
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "map-cache": "^0.2.2",
-        "source-map": "^0.5.6",
-        "source-map-resolve": "^0.5.0",
-        "use": "^3.1.0"
+        "semver": "^7.5.3"
       },
       "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/snapdragon-node": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
-      "dev": true,
-      "dependencies": {
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.0",
-        "snapdragon-util": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/snapdragon-node/node_modules/define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-      "dev": true,
-      "dependencies": {
-        "is-descriptor": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/snapdragon-node/node_modules/is-accessor-descriptor": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-      "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-      "deprecated": "Please upgrade to v1.0.1",
-      "dev": true,
-      "dependencies": {
-        "kind-of": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/snapdragon-node/node_modules/is-data-descriptor": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-      "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-      "deprecated": "Please upgrade to v1.0.1",
-      "dev": true,
-      "dependencies": {
-        "kind-of": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/snapdragon-node/node_modules/is-descriptor": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-      "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-      "dev": true,
-      "dependencies": {
-        "is-accessor-descriptor": "^1.0.0",
-        "is-data-descriptor": "^1.0.0",
-        "kind-of": "^6.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/snapdragon-util": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
-      "dev": true,
-      "dependencies": {
-        "kind-of": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/snapdragon-util/node_modules/kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/snapdragon/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/snapdragon/node_modules/define-property": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-      "dev": true,
-      "dependencies": {
-        "is-descriptor": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/snapdragon/node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-      "dev": true,
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
+        "node": ">=10"
       }
     },
     "node_modules/source-map": {
@@ -3944,64 +2275,6 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-resolve": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
-      "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
-      "deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
-      "dev": true,
-      "dependencies": {
-        "atob": "^2.1.1",
-        "decode-uri-component": "^0.2.0",
-        "resolve-url": "^0.2.1",
-        "source-map-url": "^0.4.0",
-        "urix": "^0.1.0"
-      }
-    },
-    "node_modules/source-map-url": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
-      "deprecated": "See https://github.com/lydell/source-map-url#deprecated",
-      "dev": true
-    },
-    "node_modules/split-string": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
-      "dev": true,
-      "dependencies": {
-        "extend-shallow": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/static-extend": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
-      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
-      "dev": true,
-      "dependencies": {
-        "define-property": "^0.2.5",
-        "object-copy": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/static-extend/node_modules/define-property": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-      "dev": true,
-      "dependencies": {
-        "is-descriptor": "^0.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4070,19 +2343,6 @@
         "safe-buffer": "~5.2.0"
       }
     },
-    "node_modules/string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-      "dev": true,
-      "dependencies": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/string.prototype.trim": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
@@ -4121,36 +2381,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/strip-eof": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/subarg": {
@@ -4216,18 +2446,6 @@
         "path-parse": "^1.0.6"
       }
     },
-    "node_modules/term-size": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
-      "integrity": "sha512-7dPUZQGy/+m3/wjVz3ZW5dobSoD/02NxJpoXUX0WIyjfVS3l0c+b/+9phIDFA7FHzkYtwtMFgeGZ/Y8jVTeqQQ==",
-      "dev": true,
-      "dependencies": {
-        "execa": "^0.7.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -4240,15 +2458,6 @@
       "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
       "dependencies": {
         "readable-stream": "2 || 3"
-      }
-    },
-    "node_modules/timed-out": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/timers-browserify": {
@@ -4283,56 +2492,16 @@
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true
     },
-    "node_modules/to-object-path": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
-      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
-      "dev": true,
-      "dependencies": {
-        "kind-of": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/to-object-path/node_modules/kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/to-regex": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
-      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
-      "dev": true,
-      "dependencies": {
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "regex-not": "^1.0.2",
-        "safe-regex": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/to-regex-range": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
       "dependencies": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
+        "is-number": "^7.0.0"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8.0"
       }
     },
     "node_modules/touch": {
@@ -4453,128 +2622,6 @@
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true
     },
-    "node_modules/union-value": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
-      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
-      "dev": true,
-      "dependencies": {
-        "arr-union": "^3.1.0",
-        "get-value": "^2.0.6",
-        "is-extendable": "^0.1.1",
-        "set-value": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/unique-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
-      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
-      "dev": true,
-      "dependencies": {
-        "crypto-random-string": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/unset-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
-      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
-      "dev": true,
-      "dependencies": {
-        "has-value": "^0.3.1",
-        "isobject": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/unset-value/node_modules/has-value": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
-      "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
-      "dev": true,
-      "dependencies": {
-        "get-value": "^2.0.3",
-        "has-values": "^0.1.4",
-        "isobject": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/unset-value/node_modules/has-value/node_modules/isobject": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-      "dev": true,
-      "dependencies": {
-        "isarray": "1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/unset-value/node_modules/has-values": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-      "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/unzip-response": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-      "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/upath": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
-      "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
-      "dev": true,
-      "engines": {
-        "node": ">=4",
-        "yarn": "*"
-      }
-    },
-    "node_modules/update-notifier": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
-      "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
-      "dev": true,
-      "dependencies": {
-        "boxen": "^1.2.1",
-        "chalk": "^2.0.1",
-        "configstore": "^3.0.0",
-        "import-lazy": "^2.1.0",
-        "is-ci": "^1.0.10",
-        "is-installed-globally": "^0.1.0",
-        "is-npm": "^1.0.0",
-        "latest-version": "^3.0.0",
-        "semver-diff": "^2.0.0",
-        "xdg-basedir": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/urix": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
-      "deprecated": "Please see https://github.com/lydell/urix#deprecated",
-      "dev": true
-    },
     "node_modules/url": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
@@ -4585,32 +2632,11 @@
         "querystring": "0.2.0"
       }
     },
-    "node_modules/url-parse-lax": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-      "dev": true,
-      "dependencies": {
-        "prepend-http": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/url/node_modules/punycode": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
       "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
       "dev": true
-    },
-    "node_modules/use": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
-      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/util": {
       "version": "0.10.4",
@@ -4646,18 +2672,6 @@
         "defaults": "^1.0.3"
       }
     },
-    "node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
-      }
-    },
     "node_modules/which-typed-array": {
       "version": "1.1.20",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
@@ -4679,43 +2693,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/widest-line": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
-      "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
-    },
-    "node_modules/write-file-atomic": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
-      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.2"
-      }
-    },
-    "node_modules/xdg-basedir": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -4725,12 +2707,6 @@
       "engines": {
         "node": ">=0.4"
       }
-    },
-    "node_modules/yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "statsim-profile",
   "version": "0.0.5",
   "description": "",
-  "main": "src/main.js",
+  "main": "src/core/index.js",
+  "bin": {
+    "statsim-profile": "src/cli/index.js"
+  },
   "dependencies": {
     "csv-parse": "^4.6.3",
     "drag-and-drop-files": "0.0.1",
@@ -19,14 +22,18 @@
     "uglify-es": "^3.3.9"
   },
   "scripts": {
-    "build": "browserify src/main.js | uglifyjs -cm > dist/bundle.js",
-    "build-dev": "browserify src/main.js -o dist/bundle.js --debug",
+    "build:main": "browserify src/main.js | uglifyjs -cm > dist/bundle.js",
+    "build:worker": "browserify src/worker/profile-worker.js | uglifyjs -cm > dist/worker-bundle.js",
+    "build": "mkdir -p dist && npm run build:main && npm run build:worker",
+    "build-dev:main": "browserify src/main.js -o dist/bundle.js --debug",
+    "build-dev:worker": "browserify src/worker/profile-worker.js -o dist/worker-bundle.js --debug",
+    "build-dev": "mkdir -p dist && npm run build-dev:main && npm run build-dev:worker",
     "serve:test": "node tests/support/static-server.js",
-    "test": "npm run test:e2e",
+    "test": "npm run test:unit && npm run test:e2e",
     "test:e2e": "npm run build-dev && playwright test",
     "test:e2e:headed": "npm run build-dev && PW_KEEP_OPEN=1 playwright test --headed",
     "watch": "nodemon --watch src --ext js,css,html --exec 'npm run build-dev'",
-    "test:unit": "echo \"No unit tests configured\" && exit 0"
+    "test:unit": "tape tests/unit/*.test.js"
   },
   "author": "Anton Zemlyansky",
   "license": "ISC"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@playwright/test": "^1.49.1",
     "browserify": "^16.5.0",
-    "nodemon": "^1.19.4",
+    "nodemon": "^3.1.11",
     "tape": "^4.11.0",
     "uglify-es": "^3.3.9"
   },

--- a/package.json
+++ b/package.json
@@ -1,10 +1,24 @@
 {
-  "name": "statsim-profile",
-  "version": "0.0.5",
-  "description": "",
+  "name": "@statsim/profile",
+  "version": "0.1.0",
+  "description": "Streaming CSV data profiler with online statistics",
   "main": "src/core/index.js",
   "bin": {
-    "statsim-profile": "src/cli/index.js"
+    "statsim-profile": "src/cli/index.js",
+    "sprofile": "src/cli/index.js"
+  },
+  "files": [
+    "src/core/",
+    "src/cli/",
+    "dist/",
+    "css/",
+    "fonts/",
+    "index.html",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
   },
   "dependencies": {
     "csv-parse": "^4.6.3",
@@ -22,6 +36,7 @@
     "uglify-es": "^3.3.9"
   },
   "scripts": {
+    "prepublishOnly": "npm run build",
     "build:main": "browserify src/main.js | uglifyjs -cm > dist/bundle.js",
     "build:worker": "browserify src/worker/profile-worker.js | uglifyjs -cm > dist/worker-bundle.js",
     "build": "mkdir -p dist && npm run build:main && npm run build:worker",
@@ -36,5 +51,5 @@
     "test:unit": "tape tests/unit/*.test.js"
   },
   "author": "Anton Zemlyansky",
-  "license": "ISC"
+  "license": "MIT"
 }

--- a/src/cli/format-summary.js
+++ b/src/cli/format-summary.js
@@ -1,0 +1,144 @@
+var getVariableType = require('../core/index').getVariableType
+
+var BOLD = '\x1b[1m'
+var DIM = '\x1b[2m'
+var CYAN = '\x1b[36m'
+var GREEN = '\x1b[32m'
+var YELLOW = '\x1b[33m'
+var RESET = '\x1b[0m'
+
+function pad (str, width) {
+  str = String(str)
+  while (str.length < width) str += ' '
+  return str
+}
+
+function padLeft (str, width) {
+  str = String(str)
+  while (str.length < width) str = ' ' + str
+  return str
+}
+
+function formatNumber (n) {
+  if (n >= 1000000) return (n / 1000000).toFixed(1) + 'M'
+  if (n >= 1000) return (n / 1000).toFixed(1) + 'K'
+  return String(n)
+}
+
+function formatSummary (result, useColor) {
+  if (typeof useColor === 'undefined') useColor = true
+  var b = useColor ? BOLD : ''
+  var d = useColor ? DIM : ''
+  var c = useColor ? CYAN : ''
+  var g = useColor ? GREEN : ''
+  var y = useColor ? YELLOW : ''
+  var r = useColor ? RESET : ''
+
+  var lines = []
+
+  // Dataset header
+  lines.push('')
+  lines.push('  ' + b + result.name + r)
+  lines.push('  ' + d + '─'.repeat(Math.max(result.name.length, 30)) + r)
+
+  // Summary stats
+  var missingCells = 0
+  result.columns.forEach(function (col) {
+    if (col.countTypes.missing) missingCells += col.countTypes.missing
+  })
+  var totalCells = result.n * result.columns.length
+  var missingPct = totalCells > 0 ? (100 * missingCells / totalCells).toFixed(1) : '0.0'
+
+  lines.push('  ' + pad('Variables:', 16) + b + result.columns.length + r)
+  lines.push('  ' + pad('Observations:', 16) + b + formatNumber(result.n) + r)
+  if (result.empty > 0) {
+    lines.push('  ' + pad('Empty lines:', 16) + b + result.empty + r)
+  }
+  lines.push('  ' + pad('Missing cells:', 16) + b + missingCells + r + ' (' + missingPct + '%)')
+  lines.push('  ' + pad('Size:', 16) + b + (result.size / 1024).toFixed(2) + r + ' kB')
+  lines.push('')
+
+  // Column details
+  var nameWidth = 4
+  result.columns.forEach(function (col) {
+    if (col.name.length > nameWidth) nameWidth = col.name.length
+  })
+  nameWidth = Math.min(nameWidth + 2, 30)
+
+  result.columns.forEach(function (col) {
+    var type = getVariableType(col.countTypes, col.countValues, result.n)
+    var typeColor = type === 'Number' ? g : type === 'String' ? c : y
+    var line = '  ' + b + pad(col.name, nameWidth) + r
+    line += typeColor + pad(type, 14) + r
+
+    if (col.stats) {
+      var stats = col.stats
+      line += d + 'min: ' + r + padLeft(stats.Min.toFixed(2), 8)
+      line += d + '  max: ' + r + padLeft(stats.Max.toFixed(2), 8)
+      line += d + '  avg: ' + r + padLeft(stats.Avg.toFixed(2), 8)
+      line += d + '  std: ' + r + padLeft(stats.Std.toFixed(2), 8)
+    }
+
+    if (col.countValues) {
+      var keys = Object.keys(col.countValues)
+      line += d + 'unique: ' + r + keys.length + ' (' + (100 * keys.length / result.n).toFixed(2) + '%)'
+
+      if (keys.length <= 20) {
+        var sorted = keys.sort(function (a, b) {
+          return col.countValues[b] - col.countValues[a]
+        })
+        line += d + '  top: ' + r + '"' + sorted[0] + '" (' + col.countValues[sorted[0]] + ')'
+      }
+    }
+
+    if (col.countTypes.missing) {
+      var pct = (100 * col.countTypes.missing / result.n).toFixed(2)
+      line += d + '  missing: ' + r + col.countTypes.missing + ' (' + pct + '%)'
+    }
+
+    lines.push(line)
+  })
+
+  // Data head table
+  if (result.head && result.head.length > 0) {
+    lines.push('')
+    lines.push('  ' + d + 'First ' + result.head.length + ' of ' + result.n + ' rows' + r)
+
+    var colNames = result.columns.map(function (col) { return col.name })
+    var colWidths = colNames.map(function (name) { return name.length })
+    result.head.forEach(function (row) {
+      colNames.forEach(function (name, i) {
+        var val = String(row[name] != null ? row[name] : '')
+        if (val.length > colWidths[i]) colWidths[i] = val.length
+      })
+    })
+    colWidths = colWidths.map(function (w) { return Math.min(w, 20) })
+
+    var top = '  ┌' + colWidths.map(function (w) { return '─'.repeat(w + 2) }).join('┬') + '┐'
+    var mid = '  ├' + colWidths.map(function (w) { return '─'.repeat(w + 2) }).join('┼') + '┤'
+    var bot = '  └' + colWidths.map(function (w) { return '─'.repeat(w + 2) }).join('┴') + '┘'
+
+    var header = '  │' + colNames.map(function (name, i) {
+      return ' ' + b + pad(name.slice(0, colWidths[i]), colWidths[i]) + r + ' '
+    }).join('│') + '│'
+
+    lines.push(top)
+    lines.push(header)
+    lines.push(mid)
+
+    result.head.forEach(function (row) {
+      var rowLine = '  │' + colNames.map(function (name, i) {
+        var val = String(row[name] != null ? row[name] : '')
+        return ' ' + pad(val.slice(0, colWidths[i]), colWidths[i]) + ' '
+      }).join('│') + '│'
+      lines.push(rowLine)
+    })
+
+    lines.push(bot)
+  }
+
+  lines.push('')
+  return lines.join('\n')
+}
+
+module.exports = { formatSummary: formatSummary }

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -3,11 +3,15 @@
 var fs = require('fs')
 var path = require('path')
 var profileStream = require('../core/index').profileStream
+var createProgress = require('./progress').createProgress
+var formatSummary = require('./format-summary').formatSummary
+var startServe = require('./serve').startServe
 
 var args = process.argv.slice(2)
 var filePath = null
 var useStdin = false
 var delimiter = null
+var format = null
 
 for (var i = 0; i < args.length; i++) {
   if (args[i] === '--stdin') {
@@ -15,13 +19,23 @@ for (var i = 0; i < args.length; i++) {
   } else if (args[i] === '--delimiter' && args[i + 1]) {
     delimiter = args[i + 1]
     i++
+  } else if (args[i] === '--format' && args[i + 1]) {
+    format = args[i + 1]
+    i++
   } else if (args[i] === '--help' || args[i] === '-h') {
     process.stdout.write(
-      'Usage: statsim-profile [options] [file]\n\n' +
+      'Usage: sprofile [options] [file]\n\n' +
       'Options:\n' +
+      '  --format <fmt>   Output format: json, summary, serve (default: auto)\n' +
       '  --stdin          Read from stdin\n' +
       '  --delimiter <d>  Set delimiter (default: , or \\t for .tsv)\n' +
-      '  -h, --help       Show this help\n'
+      '  -h, --help       Show this help\n\n' +
+      'Examples:\n' +
+      '  sprofile data.csv                  # terminal summary\n' +
+      '  sprofile data.csv --format json    # raw JSON\n' +
+      '  sprofile data.csv --format serve   # open report in browser\n' +
+      '  sprofile data.csv --format json | jq \'.columns[0]\'\n' +
+      '  cat data.csv | sprofile --stdin\n'
     )
     process.exit(0)
   } else if (!args[i].startsWith('--')) {
@@ -31,6 +45,16 @@ for (var i = 0; i < args.length; i++) {
 
 if (!filePath && !useStdin) {
   process.stderr.write('Error: provide a file path or use --stdin\n')
+  process.exit(1)
+}
+
+// Auto-detect format: summary for TTY, json for piped
+if (!format) {
+  format = process.stdout.isTTY ? 'summary' : 'json'
+}
+
+if (['json', 'summary', 'serve'].indexOf(format) === -1) {
+  process.stderr.write('Error: unknown format "' + format + '". Use json, summary, or serve\n')
   process.exit(1)
 }
 
@@ -55,23 +79,32 @@ if (!delimiter) {
   delimiter = ext === 'tsv' ? '\t' : ','
 }
 
+var isTTY = process.stderr.isTTY
+var progress = isTTY ? createProgress(name, fileSize) : null
+
 var job = profileStream(stream, {
   delimiter: delimiter,
   name: name,
   fileSize: fileSize,
-  onProgress: fileSize > 1024 * 1024 ? function (percent) {
-    process.stderr.write('\rProfiling... ' + percent.toFixed(1) + '%')
+  onProgress: progress ? function (percent) {
+    progress.update(percent)
   } : null
 })
 
 job.promise
   .then(function (result) {
-    if (fileSize > 1024 * 1024) {
-      process.stderr.write('\n')
+    if (progress) progress.done()
+
+    if (format === 'json') {
+      process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+    } else if (format === 'summary') {
+      process.stdout.write(formatSummary(result, process.stdout.isTTY) + '\n')
+    } else if (format === 'serve') {
+      startServe(result)
     }
-    process.stdout.write(JSON.stringify(result, null, 2) + '\n')
   })
   .catch(function (err) {
+    if (progress) progress.done()
     process.stderr.write('Error: ' + err.message + '\n')
     process.exit(1)
   })

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+
+var fs = require('fs')
+var path = require('path')
+var profileStream = require('../core/index').profileStream
+
+var args = process.argv.slice(2)
+var filePath = null
+var useStdin = false
+var delimiter = null
+
+for (var i = 0; i < args.length; i++) {
+  if (args[i] === '--stdin') {
+    useStdin = true
+  } else if (args[i] === '--delimiter' && args[i + 1]) {
+    delimiter = args[i + 1]
+    i++
+  } else if (args[i] === '--help' || args[i] === '-h') {
+    process.stdout.write(
+      'Usage: statsim-profile [options] [file]\n\n' +
+      'Options:\n' +
+      '  --stdin          Read from stdin\n' +
+      '  --delimiter <d>  Set delimiter (default: , or \\t for .tsv)\n' +
+      '  -h, --help       Show this help\n'
+    )
+    process.exit(0)
+  } else if (!args[i].startsWith('--')) {
+    filePath = args[i]
+  }
+}
+
+if (!filePath && !useStdin) {
+  process.stderr.write('Error: provide a file path or use --stdin\n')
+  process.exit(1)
+}
+
+var stream
+var fileSize = 0
+var name = ''
+
+if (useStdin) {
+  stream = process.stdin
+  name = 'stdin'
+} else {
+  var resolved = path.resolve(filePath)
+  var stat = fs.statSync(resolved)
+  fileSize = stat.size
+  name = path.basename(resolved)
+  stream = fs.createReadStream(resolved)
+  stream.setEncoding('utf8')
+}
+
+if (!delimiter) {
+  var ext = name.split('.').pop().toLowerCase()
+  delimiter = ext === 'tsv' ? '\t' : ','
+}
+
+var job = profileStream(stream, {
+  delimiter: delimiter,
+  name: name,
+  fileSize: fileSize,
+  onProgress: fileSize > 1024 * 1024 ? function (percent) {
+    process.stderr.write('\rProfiling... ' + percent.toFixed(1) + '%')
+  } : null
+})
+
+job.promise
+  .then(function (result) {
+    if (fileSize > 1024 * 1024) {
+      process.stderr.write('\n')
+    }
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+  })
+  .catch(function (err) {
+    process.stderr.write('Error: ' + err.message + '\n')
+    process.exit(1)
+  })

--- a/src/cli/progress.js
+++ b/src/cli/progress.js
@@ -1,0 +1,53 @@
+var SPINNER = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
+var BAR_WIDTH = 20
+var CLEAR = '\x1b[2K\r'
+
+function createProgress (name, fileSize) {
+  var frame = 0
+  var interval = null
+  var lastPercent = -1
+
+  function renderBar (percent) {
+    var filled = Math.round(BAR_WIDTH * percent / 100)
+    var empty = BAR_WIDTH - filled
+    var bar = '\x1b[36m' + SPINNER[frame % SPINNER.length] + '\x1b[0m'
+    bar += ' Profiling \x1b[1m' + name + '\x1b[0m  '
+    bar += '['
+    bar += '\x1b[36m' + '█'.repeat(filled) + '\x1b[0m'
+    bar += '░'.repeat(empty)
+    bar += '] ' + percent.toFixed(0) + '%'
+    process.stderr.write(CLEAR + bar)
+  }
+
+  function renderSpinner () {
+    var spinner = '\x1b[36m' + SPINNER[frame % SPINNER.length] + '\x1b[0m'
+    process.stderr.write(CLEAR + spinner + ' Profiling \x1b[1m' + name + '\x1b[0m...')
+  }
+
+  if (!fileSize) {
+    interval = setInterval(function () {
+      frame++
+      renderSpinner()
+    }, 80)
+    renderSpinner()
+  }
+
+  return {
+    update: function (percent) {
+      frame++
+      if (fileSize) {
+        var rounded = Math.round(percent)
+        if (rounded !== lastPercent) {
+          lastPercent = rounded
+          renderBar(percent)
+        }
+      }
+    },
+    done: function () {
+      if (interval) clearInterval(interval)
+      process.stderr.write(CLEAR)
+    }
+  }
+}
+
+module.exports = { createProgress: createProgress }

--- a/src/cli/serve.js
+++ b/src/cli/serve.js
@@ -1,0 +1,96 @@
+var fs = require('fs')
+var path = require('path')
+var http = require('http')
+var child_process = require('child_process')
+
+var MIME_TYPES = {
+  '.css': 'text/css; charset=utf-8',
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.ttf': 'font/ttf',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2'
+}
+
+function getMimeType (filePath) {
+  var ext = path.extname(filePath).toLowerCase()
+  return MIME_TYPES[ext] || 'application/octet-stream'
+}
+
+function openBrowser (url) {
+  var cmd
+  if (process.platform === 'darwin') cmd = 'open'
+  else if (process.platform === 'win32') cmd = 'start'
+  else cmd = 'xdg-open'
+  child_process.exec(cmd + ' ' + url)
+}
+
+function startServe (result) {
+  var rootDir = path.resolve(__dirname, '..', '..')
+  var resultJson = JSON.stringify(result)
+
+  var server = http.createServer(function (req, res) {
+    var url
+    try {
+      url = new URL(req.url, 'http://' + req.headers.host)
+    } catch (e) {
+      res.writeHead(400)
+      res.end('Bad Request')
+      return
+    }
+
+    // API endpoint for the profiling result
+    if (url.pathname === '/api/result') {
+      res.writeHead(200, {
+        'Content-Type': 'application/json; charset=utf-8',
+        'Access-Control-Allow-Origin': '*'
+      })
+      res.end(resultJson)
+      return
+    }
+
+    // Serve static files
+    var pathname = url.pathname === '/' ? '/index.html' : url.pathname
+    var normalizedPath = path.normalize(pathname)
+      .replace(/^(\.\.[/\\])+/, '')
+      .replace(/^[/\\]+/, '')
+    var filePath = path.join(rootDir, normalizedPath)
+
+    if (!filePath.startsWith(rootDir)) {
+      res.writeHead(403)
+      res.end('Forbidden')
+      return
+    }
+
+    if (fs.existsSync(filePath) && fs.statSync(filePath).isDirectory()) {
+      filePath = path.join(filePath, 'index.html')
+    }
+
+    fs.readFile(filePath, function (err, contents) {
+      if (err) {
+        res.writeHead(err.code === 'ENOENT' ? 404 : 500)
+        res.end(err.code === 'ENOENT' ? 'Not Found' : 'Internal Server Error')
+        return
+      }
+      res.writeHead(200, { 'Content-Type': getMimeType(filePath) })
+      res.end(contents)
+    })
+  })
+
+  server.listen(0, '127.0.0.1', function () {
+    var port = server.address().port
+    var url = 'http://127.0.0.1:' + port
+    process.stderr.write('\x1b[36m✓\x1b[0m Report ready at \x1b[1m' + url + '\x1b[0m\n')
+    process.stderr.write('  Press Ctrl+C to stop\n')
+    openBrowser(url)
+  })
+
+  function shutdown () {
+    server.close(function () { process.exit(0) })
+  }
+  process.on('SIGINT', shutdown)
+  process.on('SIGTERM', shutdown)
+}
+
+module.exports = { startServe: startServe }

--- a/src/core/classify.js
+++ b/src/core/classify.js
@@ -1,0 +1,38 @@
+var MISSING_MARKERS = require('./constants').MISSING_MARKERS
+
+function classifyValue (val) {
+  var type = typeof val
+  if (type === 'number') {
+    return isNaN(val) ? 'missing' : 'number'
+  }
+  if (type === 'string') {
+    if (!val.length || MISSING_MARKERS.includes(val)) {
+      return 'missing'
+    }
+    return 'string'
+  }
+  return 'other'
+}
+
+function getVariableType (countTypes, countValues, n) {
+  if (countValues) {
+    var k = Object.keys(countValues).length
+    if (k === 2) {
+      return 'Boolean'
+    } else if (k < n / 2) {
+      return 'Categorical'
+    }
+  }
+  if (countTypes['number'] && (countTypes['number'] > n / 2)) {
+    return 'Number'
+  } else if (countTypes['string'] && (countTypes['string'] > n / 2)) {
+    return 'String'
+  } else {
+    return 'Mixed'
+  }
+}
+
+module.exports = {
+  classifyValue: classifyValue,
+  getVariableType: getVariableType
+}

--- a/src/core/columns.js
+++ b/src/core/columns.js
@@ -1,0 +1,57 @@
+var Stats = require('online-stats')
+var classifyValue = require('./classify').classifyValue
+var constants = require('./constants')
+
+function initColumns (parserColumns) {
+  var columns = []
+  parserColumns.forEach(function (c) {
+    var column = Object.assign({}, c)
+    column.stats = Stats.Series([
+      { stat: Stats.Mean(), name: 'Avg' },
+      { stat: Stats.Variance({ddof: constants.VARIANCE_DDOF}), name: 'Var' },
+      { stat: Stats.Std(), name: 'Std' },
+      { stat: Stats.Min(), name: 'Min' },
+      { stat: Stats.Max(), name: 'Max' }
+    ])
+    column.hist = Stats.Histogram(20, true)
+    column.countValues = Stats.Count()
+    column.countTypes = Stats.Count()
+    columns.push(column)
+  })
+  return columns
+}
+
+function updateColumns (columns, row, n) {
+  columns.forEach(function (column) {
+    var val = row[column.name]
+    var realType = classifyValue(val)
+    column.countTypes(realType)
+
+    if (n % constants.HEURISTIC_CHECK_INTERVAL === 0) {
+      if (column.countValues && (Object.keys(column.countValues.values).length > constants.MAX_UNIQUE_VALUES)) {
+        delete column.countValues
+      }
+      if (column.stats) {
+        var numcount = column.countTypes.values['number']
+        if (!numcount || (numcount / n < constants.MIN_NUMERIC_RATIO)) {
+          delete column.stats
+          delete column.hist
+        }
+      }
+    }
+
+    if (column.stats && (typeof val === 'number') && !isNaN(val)) {
+      column.stats(val)
+      column.hist(val)
+    }
+
+    if (column.countValues) {
+      column.countValues(val)
+    }
+  })
+}
+
+module.exports = {
+  initColumns: initColumns,
+  updateColumns: updateColumns
+}

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -1,0 +1,35 @@
+// ProfileResult schema version
+var RESULT_VERSION = 1
+
+// Values treated as missing data
+var MISSING_MARKERS = ['NA', 'na', '-', 'NULL', 'NAN', 'NaN', 'nan']
+
+// Stop counting unique values above this threshold
+var MAX_UNIQUE_VALUES = 10000
+
+// Drop numeric stats if fewer than this ratio are numbers
+var MIN_NUMERIC_RATIO = 0.7
+
+// How often (in rows) to run heuristic checks
+var HEURISTIC_CHECK_INTERVAL = 100
+
+// Number of head rows to retain
+var HEAD_SIZE = 5
+
+// Stats conventions:
+// - Variance uses ddof=1 (sample variance, Bessel's correction)
+// - Std uses ddof=0 (population std) — this is the existing behavior
+//   because online-series passes values by custom name ('Var') which
+//   doesn't match online-std's lookup key ('variance'), so Std falls
+//   back to its own internal variance with default ddof=0
+var VARIANCE_DDOF = 1
+
+module.exports = {
+  RESULT_VERSION: RESULT_VERSION,
+  MISSING_MARKERS: MISSING_MARKERS,
+  MAX_UNIQUE_VALUES: MAX_UNIQUE_VALUES,
+  MIN_NUMERIC_RATIO: MIN_NUMERIC_RATIO,
+  HEURISTIC_CHECK_INTERVAL: HEURISTIC_CHECK_INTERVAL,
+  HEAD_SIZE: HEAD_SIZE,
+  VARIANCE_DDOF: VARIANCE_DDOF
+}

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -1,0 +1,103 @@
+var parseStream = require('csv-parse')
+var through2 = require('through2')
+var initColumns = require('./columns').initColumns
+var updateColumns = require('./columns').updateColumns
+var finalizeResult = require('./result').finalizeResult
+var HEAD_SIZE = require('./constants').HEAD_SIZE
+var getVariableType = require('./classify').getVariableType
+var classifyValue = require('./classify').classifyValue
+
+function profileStream (readableStream, opts) {
+  opts = opts || {}
+  var delimiter = opts.delimiter || ','
+  var name = opts.name || ''
+  var fileSize = opts.fileSize || 0
+  var onProgress = opts.onProgress || null
+
+  var n = 0
+  var columns = []
+  var head = []
+  var progressBytes = 0
+
+  var byteStep = fileSize > 0 ? fileSize / 500 : 200000
+  if (byteStep > 200000) byteStep = 200000
+
+  var parser = parseStream({
+    delimiter: delimiter,
+    cast: true,
+    columns: true,
+    comment: '#',
+    trim: true,
+    relax_column_count: true,
+    skip_empty_lines: true,
+    skip_lines_with_error: true
+  })
+
+  var progress = through2(function (chunk, enc, callback) {
+    progressBytes += chunk.length
+    if (onProgress && fileSize > 0) {
+      var percent = ((progressBytes / fileSize) * 100)
+      onProgress(percent)
+    }
+    this.push(chunk)
+    callback()
+  })
+
+  var stopped = false
+  var resolve
+  var reject
+
+  var promise = new Promise(function (res, rej) {
+    resolve = res
+    reject = rej
+  })
+
+  function finalize () {
+    var result = finalizeResult({
+      n: n,
+      name: name,
+      head: head,
+      parserInfo: parser.info || {},
+      size: progressBytes,
+      columns: columns
+    })
+    resolve(result)
+  }
+
+  readableStream
+    .pipe(progress)
+    .pipe(parser)
+    .on('data', function (obj) {
+      if (!n) {
+        columns = initColumns(parser.options.columns)
+      }
+      if (n < HEAD_SIZE) {
+        head.push(obj)
+      }
+      updateColumns(columns, obj, n)
+      n += 1
+    })
+    .on('end', finalize)
+    .on('error', function (err) {
+      reject(err)
+    })
+
+  function stop () {
+    if (!stopped) {
+      stopped = true
+      readableStream.destroy()
+      finalize()
+    }
+  }
+
+  return {
+    promise: promise,
+    stop: stop
+  }
+}
+
+module.exports = {
+  profileStream: profileStream,
+  getVariableType: getVariableType,
+  classifyValue: classifyValue
+}

--- a/src/core/result.js
+++ b/src/core/result.js
@@ -1,0 +1,35 @@
+var RESULT_VERSION = require('./constants').RESULT_VERSION
+
+function finalizeResult (opts) {
+  var n = opts.n
+  var name = opts.name
+  var head = opts.head
+  var parserInfo = opts.parserInfo
+  var size = opts.size
+  var columns = opts.columns
+
+  return {
+    version: RESULT_VERSION,
+    n: n,
+    name: name,
+    head: head,
+    comments: parserInfo.comment_lines || 0,
+    empty: parserInfo.empty_lines || 0,
+    invalid_length: parserInfo.invalid_field_length || 0,
+    size: size,
+    record_size: n > 0 ? size / n : 0,
+    columns: columns.map(function (c) {
+      return {
+        name: c.name,
+        stats: c.stats ? c.stats.values : null,
+        hist: c.hist ? c.hist.value : null,
+        countValues: c.countValues ? c.countValues.values : null,
+        countTypes: c.countTypes ? c.countTypes.values : null
+      }
+    })
+  }
+}
+
+module.exports = {
+  finalizeResult: finalizeResult
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,548 +1,132 @@
-const parseStream = require('csv-parse')
-const ReadStream = require('filestream').read
-const Stats = require('online-stats')
-const chart = require('tui-chart')
-const through2 = require('through2')
-const dnd = require('drag-and-drop-files')
+var dnd = require('drag-and-drop-files')
+var generateOutput = require('./render/index').generateOutput
 
-const chartTheme = {
-  chart: {
-    fontFamily: 'Roboto',
-    background: {
-      color: 'red',
-      opacity: 0
-    }
-  },
-  title: {
-    fontSize: 20,
-    fontFamily: 'Roboto',
-    fontWeight: '300'
+var stopButton = document.getElementById('stop')
+var drag = document.getElementById('drag')
+
+var jobCounter = 0
+var currentJobId = null
+var worker = null
+
+function initWorker () {
+  if (typeof Worker === 'undefined') return null
+  try {
+    var w = new Worker('dist/worker-bundle.js')
+    return w
+  } catch (e) {
+    console.warn('Worker init failed, using main thread fallback:', e)
+    return null
   }
 }
 
-chart.registerTheme('chartTheme', chartTheme)
+function processWithWorker (file, delimiter) {
+  var t0 = performance.now()
+  var statsEl = document.getElementById('stats')
+  var progressBar = document.getElementById('progress')
+  progressBar.style.display = 'initial'
+  stopButton.style.display = 'initial'
 
-function createDatasetSummary (results) {
-  const container = document.createElement('div')
-  container.className = 'section summary'
+  jobCounter++
+  currentJobId = jobCounter
 
-  const title = document.createElement('h2')
-  title.innerText = results.name
-  container.appendChild(title)
+  if (!worker) {
+    worker = initWorker()
+  }
 
-  let missingCells = 0
-  results.columns.forEach(column => {
-    missingCells += column.countTypes['missing'] ? column.countTypes['missing'] : 0
+  if (!worker) {
+    processOnMainThread(file, delimiter)
+    return
+  }
+
+  var jobId = currentJobId
+
+  worker.onmessage = function (e) {
+    var type = e.data.type
+    var payload = e.data.payload
+
+    if (payload.jobId !== currentJobId) return
+
+    if (type === 'progress') {
+      var formatted = payload.percent.toFixed(1)
+      statsEl.innerText = formatted + '%'
+      progressBar.style.width = formatted + '%'
+    }
+
+    if (type === 'result') {
+      var t1 = performance.now()
+      console.log('Execution time:', t1 - t0)
+      progressBar.style.display = 'none'
+      stopButton.style.display = 'none'
+      generateOutput(document.getElementById('output'), payload.data)
+    }
+
+    if (type === 'error') {
+      progressBar.style.display = 'none'
+      stopButton.style.display = 'none'
+      console.error('Worker error:', payload.message)
+    }
+  }
+
+  worker.postMessage({
+    type: 'start',
+    payload: { jobId: jobId, file: file, delimiter: delimiter }
   })
 
-  const list = document.createElement('dl')
-  let summary = {
-    'Number of variables': results.columns.length,
-    'Number of observations': results.n,
-    'Number of empty lines': results.empty,
-    'Total size in memory': (results.size / 1024).toFixed(2) + ' kB',
-    'Average record size': (results.record_size / 1024).toFixed(2) + ' kB',
-    'Missing cells': `${missingCells} (${(100 * missingCells / (results.n * results.columns.length)).toFixed(1)}%)`
-  }
-
-  Object.keys(summary).forEach(key => {
-    const dt = document.createElement('dt')
-    dt.innerText = key + ':'
-    list.appendChild(dt)
-    const dd = document.createElement('dd')
-    dd.innerText = summary[key]
-    list.appendChild(dd)
-  })
-
-  container.appendChild(list)
-  return container
-}
-
-function createTypeSummary (results) {
-  const container = document.createElement('div')
-  container.className = 'section'
-  const data = {
-    categories: results.columns.map(c => c.name),
-    series: ['number', 'string', 'missing', 'other'].map(type => ({
-      'name': type,
-      'data': results.columns.map(c => c.countTypes[type] || 0)
-    }))
-  }
-  const options = {
-    chart: {
-      width: 980,
-      height: 400,
-      title: 'Variable types',
-      format: '1,000'
-    },
-    yAxis: {
-      title: '% of samples'
-    },
-    legend: {
-      align: 'right'
-    },
-    series: {
-      stackType: 'percent',
-      barWidth: 60
-    },
-    tooltip: {
-      grouped: true
-    }
-  }
-  chart.columnChart(container, data, options)
-  return container
-}
-
-function createHistogram (hist) {
-  const histContainer = document.createElement('div')
-  histContainer.className = 'hist-chart'
-
-  const [h, b] = hist.value
-  // const bins = h.map((_, i) => b[i].toFixed(1) + '-' + b[i + 1].toFixed(1))
-
-  const data = {
-    categories: b.slice(0, -1).map(bin => bin.toFixed(1)),
-    series: [{
-      name: 'Values',
-      data: h
-    }]
-  }
-
-  const options = {
-    chart: {
-      width: 300,
-      height: 220,
-      title: 'Distribution'
-    },
-    theme: 'chartTheme',
-    yAxis: [
-      {
-        title: 'Frequency',
-        chartType: 'column',
-        labelMargin: 5
-      }
-    ],
-    xAxis: {
-      title: 'Values'
-    },
-    series: {
-      showDot: false,
-      spline: true,
-      showLabel: false,
-      pointWidth: 3
-    },
-    legend: {
-      visible: false
-    },
-    chartExportMenu: {
-      visible: false
-    },
-    usageStatistics: false
-  }
-
-  chart.lineChart(histContainer, data, options)
-
-  return histContainer
-}
-
-function getVariableType (countTypes, countValues, n) {
-  if (countValues) {
-    const k = Object.keys(countValues).length
-    if (k === 2) {
-      return 'Boolean'
-    } else if (k < n / 2) {
-      return 'Categorical'
-    }
-  }
-  if (countTypes['number'] && (countTypes['number'] > n / 2)) {
-    return 'Number'
-  } else if (countTypes['string'] && (countTypes['string'] > n / 2)) {
-    return 'String'
-  } else {
-    return 'Mixed'
-  }
-}
-
-function createVariablesSummary (results) {
-  const container = document.createElement('div')
-  container.className = 'section'
-
-  /*
-  const title = document.createElement('h2')
-  title.innerText = 'Variables'
-  container.appendChild(title)
-  */
-
-  results.columns.forEach(column => {
-    console.log('Create summary for column:', column.name)
-    const block = document.createElement('div')
-    block.className = 'block'
-
-    const nameBlock = document.createElement('div')
-    nameBlock.className = 'name-block'
-    const name = document.createElement('h4')
-    name.innerText = column.name
-    nameBlock.appendChild(name)
-    const type = document.createElement('p')
-    type.className = 'variable-type'
-    type.innerText = getVariableType(column.countTypes, column.countValues, results.n)
-    nameBlock.appendChild(type)
-    block.appendChild(nameBlock)
-
-    const statBlock = document.createElement('div')
-    statBlock.className = 'stat-block'
-    const statTitle = document.createElement('h4')
-    statTitle.innerText = 'Statistics'
-    statBlock.appendChild(statTitle)
-    const statList = document.createElement('dl')
-    statBlock.appendChild(statList)
-    block.appendChild(statBlock)
-
-    const appendToList = (t, d) => {
-      const dt = document.createElement('dt')
-      dt.innerText = t + ':'
-      statList.appendChild(dt)
-      const dd = document.createElement('dd')
-      dd.innerText = d
-      statList.appendChild(dd)
-    }
-
-    // Show stats if exist
-    if (column.stats) {
-      Object.keys(column.stats)
-        .filter(stat => (stat !== 'n'))
-        .forEach(stat => {
-          appendToList(stat, (column.stats[stat]).toFixed(2))
-        })
-
-      // If number of unique numerical values >20, show histogram/distribution
-      if ((column.countValues === null) || (Object.keys(column.countValues).length > 20)) {
-        let hist = createHistogram(column.hist)
-        block.appendChild(hist)
-      }
-    }
-
-    // Column has counter
-    if (column.countValues) {
-      const topNumber = 5
-      const sorted = Object.keys(column.countValues).sort((a, b) => column.countValues[b] - column.countValues[a])
-      console.log('Counted values:', column.countValues, sorted)
-
-      let topValues = sorted.slice(0, topNumber)
-      let dataCounter = topValues.map(v => column.countValues[v])
-
-      appendToList('Unq', `${sorted.length} (${(100 * sorted.length / results.n).toFixed(2)}%)`)
-
-      if (topNumber < sorted.length) {
-        let other = sorted.slice(5).reduce((a, v) => a + column.countValues[v], 0)
-        topValues = topValues.concat('Other')
-        dataCounter = dataCounter.concat(other)
-      }
-
-      const chartContainer = document.createElement('div')
-      chartContainer.className = 'count-chart'
-
-      const data = {
-        categories: topValues,
-        series: [
-          {
-            name: 'Count',
-            data: dataCounter
-          }
-        ]
-      }
-      let options = {
-        chart: {
-          width: 300,
-          height: 220,
-          title: `Top ${topNumber < sorted.length ? topNumber : sorted.length} of ${sorted.length} values`,
-          format: '1,000'
-        },
-        theme: 'chartTheme',
-        yAxis: {
-          title: 'Values'
-        },
-        xAxis: {
-          title: 'Count',
-          min: 0
-        },
-        series: {
-          showLabel: false
-        },
-        legend: {
-          visible: false
-        },
-        chartExportMenu: {
-          visible: false
-        },
-        usageStatistics: false
-      }
-      chart.barChart(chartContainer, data, options)
-      block.appendChild(chartContainer)
-    }
-
-    // Missing values
-    if (column.countTypes['missing']) {
-      appendToList('Missing', `${column.countTypes['missing']} (${(100 * column.countTypes['missing'] / results.n).toFixed(2)}%)`)
-    }
-
-    container.appendChild(block)
-  })
-
-  return container
-}
-
-function createHead (results) {
-  const keys = results.columns.map(c => c.name)
-  const len = results.head.length
-
-  const container = document.createElement('div')
-  container.className = 'section datahead'
-
-  const title = document.createElement('h4')
-  title.innerText = `First ${len} of ${results.n} rows`
-  title.className = 'title'
-  container.appendChild(title)
-
-  const table = document.createElement('table')
-  const headerRow = document.createElement('tr')
-  keys.forEach(k => {
-    let th = document.createElement('th')
-    th.innerText = k
-    headerRow.appendChild(th)
-  })
-  table.appendChild(headerRow)
-
-  results.head.forEach(row => {
-    const bodyRow = document.createElement('tr')
-    keys.forEach(k => {
-      const td = document.createElement('td')
-      td.innerText = row[k]
-      bodyRow.appendChild(td)
+  stopButton.onclick = function () {
+    worker.postMessage({
+      type: 'stop',
+      payload: { jobId: jobId }
     })
-    table.appendChild(bodyRow)
-  })
-
-  container.appendChild(table)
-  return container
-}
-
-function generateOutput (el, results) {
-  // Clean output block
-  while (el.firstChild) {
-    el.removeChild(el.firstChild)
   }
-
-  // Append results
-  el.appendChild(createDatasetSummary(results))
-  el.appendChild(createTypeSummary(results))
-  el.appendChild(createVariablesSummary(results))
-  el.appendChild(createHead(results))
 }
 
-const stopButton = document.getElementById('stop')
-const drag = document.getElementById('drag')
+function processOnMainThread (file, delimiter) {
+  var t0 = performance.now()
+  var ReadStream = require('filestream').read
+  var profileStream = require('./core/index').profileStream
 
-function process (files) {
-  const t0 = performance.now()
-  const file = files[0]
-  const size = file.size
-  console.log('File size:', size)
+  var statsEl = document.getElementById('stats')
+  var progressBar = document.getElementById('progress')
 
-  // Clear body background (dnd)
-  drag.style.display = 'none'
-
-  // Initialize read stream
-
-  const stream = new ReadStream(file, { chunkSize: 10240 })
-  // const stream = new ReadStream(file, { chunkSize: size / 1000 })
-  const stats = document.getElementById('stats')
+  var stream = new ReadStream(file, { chunkSize: 10240 })
   stream.setEncoding('utf8')
 
-  // Initialize CSV transform stream for parsing
-  const ext = file.name.split('.').pop().toLowerCase()
-  console.log('Got file with extension:', ext)
+  var job = profileStream(stream, {
+    delimiter: delimiter,
+    name: file.name,
+    fileSize: file.size,
+    onProgress: function (percent) {
+      var formatted = percent.toFixed(1)
+      statsEl.innerText = formatted + '%'
+      progressBar.style.width = formatted + '%'
+    }
+  })
 
-  let delimiter
-  if (ext === 'tsv') {
-    delimiter = '\t'
-  } else {
-    delimiter = ','
+  stopButton.onclick = function () {
+    job.stop()
   }
 
-  const parser = parseStream({
-    'delimiter': delimiter,
-    'cast': true,
-    'columns': true,
-    'comment': '#',
-    'trim': true,
-    'relax_column_count': true,
-    'skip_empty_lines': true,
-    'skip_lines_with_error': true
-  })
-
-  // Initialize progress bar
-  let progressBytes = 0
-  let progressPercents = 0
-  let progressBar = document.getElementById('progress')
-  progressBar.style.display = 'initial'
-
-  let byteStep = size / 500
-  byteStep = (byteStep < 200000) ? byteStep : 200000
-
-  // Initialize through stream for stream monitoring
-  const progress = through2(function (chunk, enc, callback) {
-    progressBytes += chunk.length
-    let prevBytes = 0
-    if ((progressBytes - prevBytes) > byteStep) {
-      progressPercents = ((progressBytes / size) * 100).toFixed(1)
-      stats.innerText = progressPercents + '%'
-      progressBar.style.width = progressPercents + '%'
-      prevBytes = progressBytes
-    }
-    this.push(chunk)
-    callback()
-  })
-
-  // Key variables
-  let n = 0 // Total number of samples (rows)
-  let columns = [] // Columns and their stats
-  let head = []
-
-  // Run when stream is ended or stopped..
-  const finalize = () => {
-    const t1 = performance.now()
+  job.promise.then(function (results) {
+    var t1 = performance.now()
     console.log('Execution time:', t1 - t0)
-    const results = {
-      'n': n,
-      'name': file.name,
-      'head': head,
-      'comments': parser.info.comment_lines,
-      'empty': parser.info.empty_lines,
-      'invalid_length': parser.info.invalid_field_length,
-      'size': progressBytes,
-      'record_size': progressBytes / n,
-      'columns': columns.map(c => ({
-        'name': c.name,
-        'stats': c.stats ? c.stats.values : null,
-        'hist': c.hist ? c.hist : null,
-        'countValues': c.countValues ? c.countValues.values : null,
-        'countTypes': c.countTypes ? c.countTypes.values : null
-      }))
-    }
     progressBar.style.display = 'none'
     stopButton.style.display = 'none'
     generateOutput(document.getElementById('output'), results)
-    console.log(parser, results)
-  }
-
-  // Initialize stop button
-  stopButton.style.display = 'initial'
-  stopButton.onclick = () => {
-    stream.destroy()
-    finalize()
-  }
-
-  // Read the stream
-  stream
-    .pipe(progress)
-    .pipe(parser)
-    .on('data', (obj) => {
-      // console.log(obj)
-
-      // Run that only on start (n == 0)
-      if (!n) {
-        parser.options.columns.forEach(c => {
-          let column = Object.assign({}, c)
-          /*
-          let val = obj[column.name]
-          if (typeof val === 'number') {
-            column.type = 'number'
-          } else {
-            column.type = 'categorical'
-          }
-          */
-          column.stats = Stats.Series([
-            { stat: Stats.Mean(), name: 'Avg' },
-            { stat: Stats.Variance({ddof: 1}), name: 'Var' },
-            { stat: Stats.Std(), name: 'Std' },
-            { stat: Stats.Min(), name: 'Min' },
-            { stat: Stats.Max(), name: 'Max' }
-          ])
-
-          column.hist = Stats.Histogram(20, true)
-          column.countValues = Stats.Count()
-          column.countTypes = Stats.Count()
-
-          columns.push(column)
-        })
-      }
-
-      if (n < 5) {
-        head.push(obj)
-      }
-
-      // Iterate over all variables
-      columns.forEach(column => {
-        let val = obj[column.name]
-
-        // Determine type of value
-        let type = typeof val
-        let realType
-        if (type === 'number') {
-          if (isNaN(val)) {
-            realType = 'missing'
-          } else {
-            realType = type
-          }
-        } else if (type === 'string') {
-          if (!val.length || ['NA', 'na', '-', 'NULL', 'NAN', 'NaN', 'nan'].includes(val)) {
-            realType = 'missing'
-          } else {
-            realType = type
-          }
-        } else {
-          realType = 'other'
-        }
-        column.countTypes(realType)
-
-        if (n % 100 === 0) {
-          // Check number of values in counter
-          if (column.countValues && (Object.keys(column.countValues.values).length > 10000)) {
-            console.log('Stop counting (too many unique values): ', column.name)
-            delete column.countValues
-          }
-          // Check if too much non-numbers
-          if (column.stats) {
-            let numcount = column.countTypes.values['number']
-            if (!numcount || (numcount / n < 0.7)) {
-              console.log('Stop calculating stats (not numerical variable): ', column.name)
-              delete column.stats
-              delete column.hist
-            }
-          }
-        }
-
-        if (column.stats && (typeof val === 'number') && !isNaN(val)) {
-          column.stats(val)
-          column.hist(val)
-        }
-
-        if (column.countValues) {
-          column.countValues(val)
-        }
-      })
-
-      // Increment samples counter
-      n += 1
-    })
-    .on('end', finalize)
+  })
 }
 
-// Get files from drag and drop
+function process (files) {
+  var file = files[0]
+  drag.style.display = 'none'
+
+  var ext = file.name.split('.').pop().toLowerCase()
+  var delimiter = ext === 'tsv' ? '\t' : ','
+
+  processWithWorker(file, delimiter)
+}
 
 function onDragOver () {
-  const col = '#C9E4FF'
+  var col = '#C9E4FF'
   if (drag.style.background !== col) drag.style.background = col
 }
 
@@ -554,7 +138,6 @@ drag.addEventListener('dragover', onDragOver, false)
 drag.addEventListener('dragleave', onDragLeave, false)
 dnd(drag, process)
 
-// Get files from file input
-document.getElementById('input').onchange = (e) => {
+document.getElementById('input').onchange = function (e) {
   process(e.target.files)
 }

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,7 @@ var generateOutput = require('./render/index').generateOutput
 
 var stopButton = document.getElementById('stop')
 var drag = document.getElementById('drag')
+var urlError = document.getElementById('url-error')
 
 var jobCounter = 0
 var currentJobId = null
@@ -19,26 +20,19 @@ function initWorker () {
   }
 }
 
-function processWithWorker (file, delimiter) {
-  var t0 = performance.now()
+function showError (message) {
+  var output = document.getElementById('output')
+  while (output.firstChild) output.removeChild(output.firstChild)
+  var el = document.createElement('p')
+  el.style.color = '#e53935'
+  el.style.padding = '20px'
+  el.innerText = message
+  output.appendChild(el)
+}
+
+function setupWorkerHandler (t0) {
   var statsEl = document.getElementById('stats')
   var progressBar = document.getElementById('progress')
-  progressBar.style.display = 'initial'
-  stopButton.style.display = 'initial'
-
-  jobCounter++
-  currentJobId = jobCounter
-
-  if (!worker) {
-    worker = initWorker()
-  }
-
-  if (!worker) {
-    processOnMainThread(file, delimiter)
-    return
-  }
-
-  var jobId = currentJobId
 
   worker.onmessage = function (e) {
     var type = e.data.type
@@ -47,25 +41,56 @@ function processWithWorker (file, delimiter) {
     if (payload.jobId !== currentJobId) return
 
     if (type === 'progress') {
-      var formatted = payload.percent.toFixed(1)
-      statsEl.innerText = formatted + '%'
-      progressBar.style.width = formatted + '%'
+      if (payload.percent === null) {
+        statsEl.innerText = 'Processing...'
+        progressBar.style.width = '100%'
+        progressBar.classList.add('indeterminate')
+      } else {
+        progressBar.classList.remove('indeterminate')
+        var formatted = payload.percent.toFixed(1)
+        statsEl.innerText = formatted + '%'
+        progressBar.style.width = formatted + '%'
+      }
     }
 
     if (type === 'result') {
       var t1 = performance.now()
       console.log('Execution time:', t1 - t0)
       progressBar.style.display = 'none'
+      progressBar.classList.remove('indeterminate')
       stopButton.style.display = 'none'
       generateOutput(document.getElementById('output'), payload.data)
     }
 
     if (type === 'error') {
       progressBar.style.display = 'none'
+      progressBar.classList.remove('indeterminate')
       stopButton.style.display = 'none'
-      console.error('Worker error:', payload.message)
+      showError(payload.message)
     }
   }
+}
+
+function startJob () {
+  var progressBar = document.getElementById('progress')
+  progressBar.style.display = 'initial'
+  stopButton.style.display = 'initial'
+  jobCounter++
+  currentJobId = jobCounter
+  if (!worker) worker = initWorker()
+  return currentJobId
+}
+
+function processWithWorker (file, delimiter) {
+  var t0 = performance.now()
+  var jobId = startJob()
+
+  if (!worker) {
+    processOnMainThread(file, delimiter)
+    return
+  }
+
+  setupWorkerHandler(t0)
 
   worker.postMessage({
     type: 'start',
@@ -73,10 +98,50 @@ function processWithWorker (file, delimiter) {
   })
 
   stopButton.onclick = function () {
-    worker.postMessage({
-      type: 'stop',
-      payload: { jobId: jobId }
-    })
+    worker.postMessage({ type: 'stop', payload: { jobId: jobId } })
+  }
+}
+
+function processUrl (url, delimiter) {
+  // Validate URL
+  var parsed
+  try {
+    parsed = new URL(url)
+  } catch (e) {
+    showError('Invalid URL: ' + url)
+    return
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    showError('Only http and https URLs are supported.')
+    return
+  }
+
+  // Auto-detect delimiter from extension if not provided
+  if (!delimiter) {
+    var ext = parsed.pathname.split('.').pop().toLowerCase()
+    delimiter = ext === 'tsv' ? '\t' : ','
+  }
+
+  drag.style.display = 'none'
+  if (urlError) urlError.style.display = 'none'
+
+  var t0 = performance.now()
+  var jobId = startJob()
+
+  if (!worker) {
+    showError('Web Workers are required for URL loading.')
+    return
+  }
+
+  setupWorkerHandler(t0)
+
+  worker.postMessage({
+    type: 'start-url',
+    payload: { jobId: jobId, url: url, delimiter: delimiter }
+  })
+
+  stopButton.onclick = function () {
+    worker.postMessage({ type: 'stop', payload: { jobId: jobId } })
   }
 }
 
@@ -125,6 +190,15 @@ function process (files) {
   processWithWorker(file, delimiter)
 }
 
+// Parse delimiter param
+function parseDelimiterParam (val) {
+  if (!val) return null
+  if (val === 'tab' || val === '\t') return '\t'
+  if (val === 'comma' || val === ',') return ','
+  return null
+}
+
+// Drag and drop
 function onDragOver () {
   var col = '#C9E4FF'
   if (drag.style.background !== col) drag.style.background = col
@@ -138,6 +212,34 @@ drag.addEventListener('dragover', onDragOver, false)
 drag.addEventListener('dragleave', onDragLeave, false)
 dnd(drag, process)
 
+// File input
 document.getElementById('input').onchange = function (e) {
   process(e.target.files)
+}
+
+// URL input
+var urlInput = document.getElementById('url-input')
+var urlLoadBtn = document.getElementById('url-load')
+
+if (urlLoadBtn && urlInput) {
+  urlLoadBtn.onclick = function () {
+    var val = urlInput.value.trim()
+    if (!val) return
+    processUrl(val)
+  }
+  urlInput.addEventListener('keydown', function (e) {
+    if (e.key === 'Enter') {
+      var val = urlInput.value.trim()
+      if (!val) return
+      processUrl(val)
+    }
+  })
+}
+
+// Auto-load from query param
+var params = new URLSearchParams(window.location.search)
+var fileParam = params.get('file')
+if (fileParam) {
+  var delimParam = parseDelimiterParam(params.get('delimiter'))
+  processUrl(fileParam, delimParam)
 }

--- a/src/main.js
+++ b/src/main.js
@@ -242,4 +242,14 @@ var fileParam = params.get('file')
 if (fileParam) {
   var delimParam = parseDelimiterParam(params.get('delimiter'))
   processUrl(fileParam, delimParam)
+} else {
+  // Check if served from CLI --serve mode
+  fetch('/api/result').then(function (r) {
+    if (r.ok) return r.json()
+  }).then(function (result) {
+    if (result) {
+      drag.style.display = 'none'
+      generateOutput(document.getElementById('output'), result)
+    }
+  }).catch(function () {})
 }

--- a/src/render/index.js
+++ b/src/render/index.js
@@ -1,0 +1,312 @@
+var chart = require('tui-chart')
+var getVariableType = require('../core/index').getVariableType
+
+var chartTheme = {
+  chart: {
+    fontFamily: 'Roboto',
+    background: {
+      color: 'red',
+      opacity: 0
+    }
+  },
+  title: {
+    fontSize: 20,
+    fontFamily: 'Roboto',
+    fontWeight: '300'
+  }
+}
+
+chart.registerTheme('chartTheme', chartTheme)
+
+function createDatasetSummary (results) {
+  var container = document.createElement('div')
+  container.className = 'section summary'
+
+  var title = document.createElement('h2')
+  title.innerText = results.name
+  container.appendChild(title)
+
+  var missingCells = 0
+  results.columns.forEach(function (column) {
+    missingCells += column.countTypes['missing'] ? column.countTypes['missing'] : 0
+  })
+
+  var list = document.createElement('dl')
+  var summary = {
+    'Number of variables': results.columns.length,
+    'Number of observations': results.n,
+    'Number of empty lines': results.empty,
+    'Total size in memory': (results.size / 1024).toFixed(2) + ' kB',
+    'Average record size': (results.record_size / 1024).toFixed(2) + ' kB',
+    'Missing cells': missingCells + ' (' + (100 * missingCells / (results.n * results.columns.length)).toFixed(1) + '%)'
+  }
+
+  Object.keys(summary).forEach(function (key) {
+    var dt = document.createElement('dt')
+    dt.innerText = key + ':'
+    list.appendChild(dt)
+    var dd = document.createElement('dd')
+    dd.innerText = summary[key]
+    list.appendChild(dd)
+  })
+
+  container.appendChild(list)
+  return container
+}
+
+function createTypeSummary (results) {
+  var container = document.createElement('div')
+  container.className = 'section'
+  var data = {
+    categories: results.columns.map(function (c) { return c.name }),
+    series: ['number', 'string', 'missing', 'other'].map(function (type) {
+      return {
+        name: type,
+        data: results.columns.map(function (c) { return c.countTypes[type] || 0 })
+      }
+    })
+  }
+  var options = {
+    chart: {
+      width: 980,
+      height: 400,
+      title: 'Variable types',
+      format: '1,000'
+    },
+    yAxis: {
+      title: '% of samples'
+    },
+    legend: {
+      align: 'right'
+    },
+    series: {
+      stackType: 'percent',
+      barWidth: 60
+    },
+    tooltip: {
+      grouped: true
+    }
+  }
+  chart.columnChart(container, data, options)
+  return container
+}
+
+function createHistogram (hist) {
+  var histContainer = document.createElement('div')
+  histContainer.className = 'hist-chart'
+
+  var h = hist[0]
+  var b = hist[1]
+
+  var data = {
+    categories: b.slice(0, -1).map(function (bin) { return bin.toFixed(1) }),
+    series: [{
+      name: 'Values',
+      data: h
+    }]
+  }
+
+  var options = {
+    chart: {
+      width: 300,
+      height: 220,
+      title: 'Distribution'
+    },
+    theme: 'chartTheme',
+    yAxis: [
+      {
+        title: 'Frequency',
+        chartType: 'column',
+        labelMargin: 5
+      }
+    ],
+    xAxis: {
+      title: 'Values'
+    },
+    series: {
+      showDot: false,
+      spline: true,
+      showLabel: false,
+      pointWidth: 3
+    },
+    legend: {
+      visible: false
+    },
+    chartExportMenu: {
+      visible: false
+    },
+    usageStatistics: false
+  }
+
+  chart.lineChart(histContainer, data, options)
+
+  return histContainer
+}
+
+function createVariablesSummary (results) {
+  var container = document.createElement('div')
+  container.className = 'section'
+
+  results.columns.forEach(function (column) {
+    var block = document.createElement('div')
+    block.className = 'block'
+
+    var nameBlock = document.createElement('div')
+    nameBlock.className = 'name-block'
+    var name = document.createElement('h4')
+    name.innerText = column.name
+    nameBlock.appendChild(name)
+    var type = document.createElement('p')
+    type.className = 'variable-type'
+    type.innerText = getVariableType(column.countTypes, column.countValues, results.n)
+    nameBlock.appendChild(type)
+    block.appendChild(nameBlock)
+
+    var statBlock = document.createElement('div')
+    statBlock.className = 'stat-block'
+    var statTitle = document.createElement('h4')
+    statTitle.innerText = 'Statistics'
+    statBlock.appendChild(statTitle)
+    var statList = document.createElement('dl')
+    statBlock.appendChild(statList)
+    block.appendChild(statBlock)
+
+    var appendToList = function (t, d) {
+      var dt = document.createElement('dt')
+      dt.innerText = t + ':'
+      statList.appendChild(dt)
+      var dd = document.createElement('dd')
+      dd.innerText = d
+      statList.appendChild(dd)
+    }
+
+    if (column.stats) {
+      Object.keys(column.stats)
+        .filter(function (stat) { return stat !== 'n' })
+        .forEach(function (stat) {
+          appendToList(stat, (column.stats[stat]).toFixed(2))
+        })
+
+      if ((column.countValues === null) || (Object.keys(column.countValues).length > 20)) {
+        var hist = createHistogram(column.hist)
+        block.appendChild(hist)
+      }
+    }
+
+    if (column.countValues) {
+      var topNumber = 5
+      var sorted = Object.keys(column.countValues).sort(function (a, b) {
+        return column.countValues[b] - column.countValues[a]
+      })
+
+      var topValues = sorted.slice(0, topNumber)
+      var dataCounter = topValues.map(function (v) { return column.countValues[v] })
+
+      appendToList('Unq', sorted.length + ' (' + (100 * sorted.length / results.n).toFixed(2) + '%)')
+
+      if (topNumber < sorted.length) {
+        var other = sorted.slice(5).reduce(function (a, v) { return a + column.countValues[v] }, 0)
+        topValues = topValues.concat('Other')
+        dataCounter = dataCounter.concat(other)
+      }
+
+      var chartContainer = document.createElement('div')
+      chartContainer.className = 'count-chart'
+
+      var chartData = {
+        categories: topValues,
+        series: [
+          {
+            name: 'Count',
+            data: dataCounter
+          }
+        ]
+      }
+      var chartOptions = {
+        chart: {
+          width: 300,
+          height: 220,
+          title: 'Top ' + (topNumber < sorted.length ? topNumber : sorted.length) + ' of ' + sorted.length + ' values',
+          format: '1,000'
+        },
+        theme: 'chartTheme',
+        yAxis: {
+          title: 'Values'
+        },
+        xAxis: {
+          title: 'Count',
+          min: 0
+        },
+        series: {
+          showLabel: false
+        },
+        legend: {
+          visible: false
+        },
+        chartExportMenu: {
+          visible: false
+        },
+        usageStatistics: false
+      }
+      chart.barChart(chartContainer, chartData, chartOptions)
+      block.appendChild(chartContainer)
+    }
+
+    if (column.countTypes['missing']) {
+      appendToList('Missing', column.countTypes['missing'] + ' (' + (100 * column.countTypes['missing'] / results.n).toFixed(2) + '%)')
+    }
+
+    container.appendChild(block)
+  })
+
+  return container
+}
+
+function createHead (results) {
+  var keys = results.columns.map(function (c) { return c.name })
+  var len = results.head.length
+
+  var container = document.createElement('div')
+  container.className = 'section datahead'
+
+  var title = document.createElement('h4')
+  title.innerText = 'First ' + len + ' of ' + results.n + ' rows'
+  title.className = 'title'
+  container.appendChild(title)
+
+  var table = document.createElement('table')
+  var headerRow = document.createElement('tr')
+  keys.forEach(function (k) {
+    var th = document.createElement('th')
+    th.innerText = k
+    headerRow.appendChild(th)
+  })
+  table.appendChild(headerRow)
+
+  results.head.forEach(function (row) {
+    var bodyRow = document.createElement('tr')
+    keys.forEach(function (k) {
+      var td = document.createElement('td')
+      td.innerText = row[k]
+      bodyRow.appendChild(td)
+    })
+    table.appendChild(bodyRow)
+  })
+
+  container.appendChild(table)
+  return container
+}
+
+function generateOutput (el, results) {
+  while (el.firstChild) {
+    el.removeChild(el.firstChild)
+  }
+  el.appendChild(createDatasetSummary(results))
+  el.appendChild(createTypeSummary(results))
+  el.appendChild(createVariablesSummary(results))
+  el.appendChild(createHead(results))
+}
+
+module.exports = {
+  generateOutput: generateOutput
+}

--- a/src/worker/profile-worker.js
+++ b/src/worker/profile-worker.js
@@ -1,49 +1,138 @@
 var ReadStream = require('filestream').read
+var through2 = require('through2')
 var profileStream = require('../core/index').profileStream
 
 var currentJob = null
+
+function startFileJob (jobId, file, delimiter) {
+  var stream = new ReadStream(file, { chunkSize: 10240 })
+  stream.setEncoding('utf8')
+
+  var job = profileStream(stream, {
+    delimiter: delimiter,
+    name: file.name,
+    fileSize: file.size,
+    onProgress: function (percent) {
+      self.postMessage({
+        type: 'progress',
+        payload: { jobId: jobId, percent: percent }
+      })
+    }
+  })
+
+  currentJob = { jobId: jobId, stop: job.stop }
+
+  job.promise
+    .then(function (result) {
+      self.postMessage({
+        type: 'result',
+        payload: { jobId: jobId, data: result }
+      })
+      currentJob = null
+    })
+    .catch(function (err) {
+      self.postMessage({
+        type: 'error',
+        payload: { jobId: jobId, message: err.message }
+      })
+      currentJob = null
+    })
+}
+
+function startUrlJob (jobId, url, delimiter) {
+  fetch(url)
+    .then(function (response) {
+      if (!response.ok) {
+        throw new Error('HTTP ' + response.status + ': ' + response.statusText)
+      }
+
+      var contentLength = response.headers.get('content-length')
+      var fileSize = contentLength ? parseInt(contentLength, 10) : 0
+
+      var pathname = new URL(url).pathname
+      var name = pathname.split('/').pop() || 'remote.csv'
+
+      var passthrough = through2()
+      var reader = response.body.getReader()
+      var decoder = new TextDecoder('utf-8', { stream: true })
+
+      var job = profileStream(passthrough, {
+        delimiter: delimiter,
+        name: name,
+        fileSize: fileSize,
+        onProgress: fileSize > 0 ? function (percent) {
+          self.postMessage({
+            type: 'progress',
+            payload: { jobId: jobId, percent: percent }
+          })
+        } : null
+      })
+
+      currentJob = { jobId: jobId, stop: job.stop }
+
+      // Send indeterminate progress if no content-length
+      if (!fileSize) {
+        self.postMessage({
+          type: 'progress',
+          payload: { jobId: jobId, percent: null }
+        })
+      }
+
+      function pump () {
+        reader.read().then(function (result) {
+          if (result.done) {
+            var final = decoder.decode()
+            if (final) passthrough.write(final)
+            passthrough.end()
+            return
+          }
+          var text = decoder.decode(result.value, { stream: true })
+          passthrough.write(text)
+          pump()
+        }).catch(function (err) {
+          passthrough.destroy(err)
+        })
+      }
+      pump()
+
+      job.promise
+        .then(function (result) {
+          self.postMessage({
+            type: 'result',
+            payload: { jobId: jobId, data: result }
+          })
+          currentJob = null
+        })
+        .catch(function (err) {
+          self.postMessage({
+            type: 'error',
+            payload: { jobId: jobId, message: err.message }
+          })
+          currentJob = null
+        })
+    })
+    .catch(function (err) {
+      var message = err.message
+      if (message.indexOf('Failed to fetch') >= 0) {
+        message = 'Failed to fetch URL. The server may not allow cross-origin requests (CORS).'
+      }
+      self.postMessage({
+        type: 'error',
+        payload: { jobId: jobId, message: message }
+      })
+    })
+}
 
 self.onmessage = function (e) {
   var type = e.data.type
   var payload = e.data.payload
 
   if (type === 'start') {
-    var jobId = payload.jobId
-    var file = payload.file
-    var delimiter = payload.delimiter || ','
+    startFileJob(payload.jobId, payload.file, payload.delimiter || ',')
+  }
 
-    var stream = new ReadStream(file, { chunkSize: 10240 })
-    stream.setEncoding('utf8')
-
-    var job = profileStream(stream, {
-      delimiter: delimiter,
-      name: file.name,
-      fileSize: file.size,
-      onProgress: function (percent) {
-        self.postMessage({
-          type: 'progress',
-          payload: { jobId: jobId, percent: percent }
-        })
-      }
-    })
-
-    currentJob = { jobId: jobId, stop: job.stop }
-
-    job.promise
-      .then(function (result) {
-        self.postMessage({
-          type: 'result',
-          payload: { jobId: jobId, data: result }
-        })
-        currentJob = null
-      })
-      .catch(function (err) {
-        self.postMessage({
-          type: 'error',
-          payload: { jobId: jobId, message: err.message }
-        })
-        currentJob = null
-      })
+  if (type === 'start-url') {
+    startUrlJob(payload.jobId, payload.url, payload.delimiter || ',')
   }
 
   if (type === 'stop') {

--- a/src/worker/profile-worker.js
+++ b/src/worker/profile-worker.js
@@ -1,0 +1,54 @@
+var ReadStream = require('filestream').read
+var profileStream = require('../core/index').profileStream
+
+var currentJob = null
+
+self.onmessage = function (e) {
+  var type = e.data.type
+  var payload = e.data.payload
+
+  if (type === 'start') {
+    var jobId = payload.jobId
+    var file = payload.file
+    var delimiter = payload.delimiter || ','
+
+    var stream = new ReadStream(file, { chunkSize: 10240 })
+    stream.setEncoding('utf8')
+
+    var job = profileStream(stream, {
+      delimiter: delimiter,
+      name: file.name,
+      fileSize: file.size,
+      onProgress: function (percent) {
+        self.postMessage({
+          type: 'progress',
+          payload: { jobId: jobId, percent: percent }
+        })
+      }
+    })
+
+    currentJob = { jobId: jobId, stop: job.stop }
+
+    job.promise
+      .then(function (result) {
+        self.postMessage({
+          type: 'result',
+          payload: { jobId: jobId, data: result }
+        })
+        currentJob = null
+      })
+      .catch(function (err) {
+        self.postMessage({
+          type: 'error',
+          payload: { jobId: jobId, message: err.message }
+        })
+        currentJob = null
+      })
+  }
+
+  if (type === 'stop') {
+    if (currentJob && currentJob.jobId === payload.jobId) {
+      currentJob.stop()
+    }
+  }
+}

--- a/tests/support/fixtures/test-data.csv
+++ b/tests/support/fixtures/test-data.csv
@@ -1,0 +1,6 @@
+name,age,score
+Alice,30,95.5
+Bob,25,87.2
+Charlie,28,92.0
+Diana,35,88.8
+Eve,22,91.3

--- a/tests/support/static-server.js
+++ b/tests/support/static-server.js
@@ -10,6 +10,7 @@ const mimeTypeByExt = {
   '.css': 'text/css; charset=utf-8',
   '.html': 'text/html; charset=utf-8',
   '.js': 'application/javascript; charset=utf-8',
+  '.csv': 'text/csv; charset=utf-8',
   '.json': 'application/json; charset=utf-8',
   '.svg': 'image/svg+xml',
   '.ttf': 'font/ttf',
@@ -42,6 +43,14 @@ function resolveSafePath (pathname) {
 
 const server = http.createServer((req, res) => {
   const url = new URL(req.url, `http://${req.headers.host}`)
+
+  // Test route: returns 403 to simulate blocked/CORS-like failure
+  if (url.pathname === '/blocked') {
+    res.writeHead(403, { 'Content-Type': 'text/plain; charset=utf-8' })
+    res.end('Forbidden')
+    return
+  }
+
   const filePath = resolveSafePath(decodeURIComponent(url.pathname))
 
   if (!filePath) {

--- a/tests/unit/classify.test.js
+++ b/tests/unit/classify.test.js
@@ -1,0 +1,74 @@
+var test = require('tape')
+var classifyValue = require('../../src/core/classify').classifyValue
+var getVariableType = require('../../src/core/classify').getVariableType
+
+test('classifyValue: numbers', function (t) {
+  t.equal(classifyValue(42), 'number')
+  t.equal(classifyValue(0), 'number')
+  t.equal(classifyValue(-3.14), 'number')
+  t.equal(classifyValue(Infinity), 'number')
+  t.end()
+})
+
+test('classifyValue: NaN is missing', function (t) {
+  t.equal(classifyValue(NaN), 'missing')
+  t.end()
+})
+
+test('classifyValue: strings', function (t) {
+  t.equal(classifyValue('hello'), 'string')
+  t.equal(classifyValue('123'), 'string')
+  t.end()
+})
+
+test('classifyValue: empty string is missing', function (t) {
+  t.equal(classifyValue(''), 'missing')
+  t.end()
+})
+
+test('classifyValue: missing markers', function (t) {
+  var markers = ['NA', 'na', '-', 'NULL', 'NAN', 'NaN', 'nan']
+  markers.forEach(function (m) {
+    t.equal(classifyValue(m), 'missing', m + ' should be missing')
+  })
+  t.end()
+})
+
+test('classifyValue: other types', function (t) {
+  t.equal(classifyValue(null), 'other')
+  t.equal(classifyValue(undefined), 'other')
+  t.equal(classifyValue(true), 'other')
+  t.end()
+})
+
+test('getVariableType: Boolean (2 unique values)', function (t) {
+  var countTypes = { number: 100 }
+  var countValues = { '0': 50, '1': 50 }
+  t.equal(getVariableType(countTypes, countValues, 100), 'Boolean')
+  t.end()
+})
+
+test('getVariableType: Categorical (few unique values)', function (t) {
+  var countTypes = { string: 100 }
+  var countValues = { 'a': 40, 'b': 30, 'c': 30 }
+  t.equal(getVariableType(countTypes, countValues, 100), 'Categorical')
+  t.end()
+})
+
+test('getVariableType: Number', function (t) {
+  var countTypes = { number: 80, missing: 20 }
+  t.equal(getVariableType(countTypes, null, 100), 'Number')
+  t.end()
+})
+
+test('getVariableType: String', function (t) {
+  var countTypes = { string: 80, missing: 20 }
+  t.equal(getVariableType(countTypes, null, 100), 'String')
+  t.end()
+})
+
+test('getVariableType: Mixed', function (t) {
+  var countTypes = { number: 30, string: 30, missing: 40 }
+  t.equal(getVariableType(countTypes, null, 100), 'Mixed')
+  t.end()
+})

--- a/tests/unit/columns.test.js
+++ b/tests/unit/columns.test.js
@@ -1,0 +1,66 @@
+var test = require('tape')
+var initColumns = require('../../src/core/columns').initColumns
+var updateColumns = require('../../src/core/columns').updateColumns
+
+test('initColumns creates stats objects for each column', function (t) {
+  var cols = initColumns([{ name: 'a' }, { name: 'b' }])
+  t.equal(cols.length, 2)
+  t.equal(cols[0].name, 'a')
+  t.equal(cols[1].name, 'b')
+  cols.forEach(function (c) {
+    t.ok(c.stats, 'has stats')
+    t.ok(c.hist, 'has hist')
+    t.ok(c.countValues, 'has countValues')
+    t.ok(c.countTypes, 'has countTypes')
+  })
+  t.end()
+})
+
+test('updateColumns accumulates numeric stats', function (t) {
+  var cols = initColumns([{ name: 'x' }])
+  var values = [1, 2, 3, 4, 5]
+  values.forEach(function (v, i) {
+    updateColumns(cols, { x: v }, i)
+  })
+  var stats = cols[0].stats.values
+  t.equal(stats.Avg, 3, 'mean is 3')
+  t.equal(stats.Min, 1, 'min is 1')
+  t.equal(stats.Max, 5, 'max is 5')
+  t.ok(stats.Var > 0, 'variance is positive')
+  t.ok(stats.Std > 0, 'std is positive')
+  t.end()
+})
+
+test('updateColumns counts types', function (t) {
+  var cols = initColumns([{ name: 'x' }])
+  updateColumns(cols, { x: 1 }, 0)
+  updateColumns(cols, { x: 'hello' }, 1)
+  updateColumns(cols, { x: '' }, 2)
+  var types = cols[0].countTypes.values
+  t.equal(types.number, 1)
+  t.equal(types.string, 1)
+  t.equal(types.missing, 1)
+  t.end()
+})
+
+test('updateColumns drops stats for non-numeric columns', function (t) {
+  var cols = initColumns([{ name: 'x' }])
+  // Feed 100 string values to trigger heuristic at row 100
+  for (var i = 0; i < 101; i++) {
+    updateColumns(cols, { x: 'text' + i }, i)
+  }
+  t.equal(cols[0].stats, undefined, 'stats dropped')
+  t.equal(cols[0].hist, undefined, 'hist dropped')
+  t.end()
+})
+
+test('updateColumns counts unique values', function (t) {
+  var cols = initColumns([{ name: 'x' }])
+  updateColumns(cols, { x: 'a' }, 0)
+  updateColumns(cols, { x: 'b' }, 1)
+  updateColumns(cols, { x: 'a' }, 2)
+  var cv = cols[0].countValues.values
+  t.equal(cv.a, 2)
+  t.equal(cv.b, 1)
+  t.end()
+})

--- a/tests/unit/result.test.js
+++ b/tests/unit/result.test.js
@@ -1,0 +1,75 @@
+var test = require('tape')
+var initColumns = require('../../src/core/columns').initColumns
+var updateColumns = require('../../src/core/columns').updateColumns
+var finalizeResult = require('../../src/core/result').finalizeResult
+
+test('finalizeResult produces versioned ProfileResult', function (t) {
+  var cols = initColumns([{ name: 'x' }])
+  for (var i = 0; i < 5; i++) {
+    updateColumns(cols, { x: i + 1 }, i)
+  }
+
+  var result = finalizeResult({
+    n: 5,
+    name: 'test.csv',
+    head: [{ x: 1 }, { x: 2 }],
+    parserInfo: { comment_lines: 0, empty_lines: 1, invalid_field_length: 0 },
+    size: 100,
+    columns: cols
+  })
+
+  t.equal(result.version, 1, 'has version')
+  t.equal(result.n, 5, 'row count')
+  t.equal(result.name, 'test.csv', 'filename')
+  t.equal(result.head.length, 2, 'head rows')
+  t.equal(result.empty, 1, 'empty lines')
+  t.equal(result.size, 100, 'size')
+  t.equal(result.record_size, 20, 'record_size = size/n')
+
+  t.equal(result.columns.length, 1)
+  var col = result.columns[0]
+  t.equal(col.name, 'x')
+  t.ok(col.stats, 'has stats')
+  t.equal(col.stats.Avg, 3, 'mean is 3')
+  t.ok(col.countTypes, 'has countTypes')
+  t.equal(col.countTypes.number, 5)
+  t.ok(col.countValues, 'has countValues')
+  t.ok(Array.isArray(col.hist), 'hist is plain array')
+  t.equal(col.hist.length, 2, 'hist has [counts, boundaries]')
+  t.end()
+})
+
+test('finalizeResult handles missing parserInfo', function (t) {
+  var cols = initColumns([{ name: 'a' }])
+  updateColumns(cols, { a: 1 }, 0)
+
+  var result = finalizeResult({
+    n: 1,
+    name: 'f.csv',
+    head: [{ a: 1 }],
+    parserInfo: {},
+    size: 10,
+    columns: cols
+  })
+
+  t.equal(result.comments, 0)
+  t.equal(result.empty, 0)
+  t.equal(result.invalid_length, 0)
+  t.end()
+})
+
+test('finalizeResult handles zero rows', function (t) {
+  var result = finalizeResult({
+    n: 0,
+    name: 'empty.csv',
+    head: [],
+    parserInfo: {},
+    size: 0,
+    columns: []
+  })
+
+  t.equal(result.n, 0)
+  t.equal(result.record_size, 0)
+  t.equal(result.columns.length, 0)
+  t.end()
+})


### PR DESCRIPTION
- Refactored the app from monolithic `src/main.js` into separated modules: `src/core`, `src/render`, `src/worker`, and `src/cli`.
- Added reusable core profiling API (`profileStream`) and versioned `ProfileResult` output.
- Switched browser processing to Web Workers with progress updates and stop support.
- Added URL-based CSV profiling (`?file=...`) plus URL input field in the UI.
- Added worker-side remote URL fetch/stream handling with HTTP/CORS-friendly error handling.
- Enhanced CLI with `sprofile` alias and output modes: `json`, `summary`, `serve`.
- Added polished CLI UX: ANSI progress indicator (`src/cli/progress.js`) and formatted terminal summary (`src/cli/format-summary.js`).
- Added local browser report mode via CLI (`src/cli/serve.js`) that serves result data through `/api/result`.
- Prepared npm package for publishing as `@statsim/profile` (`0.1.0`) with MIT license and publish config.
- Updated docs/content (`README.md`, `AGENTS.md`, `index.html`) to reflect new browser + CLI capabilities.
- Expanded tests for new behavior (core unit tests and E2E URL/input/error flows); current suite passes.